### PR TITLE
Namespace Changes and Few minor readme fixes for streams.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Example for **real-time updates** from a collection in fabric:
   print("Subscribe to employees collection...")
   client = C8Client(protocol='https', host=region, port=443)
   fabric = client.fabric(tenant="demotenant", name="demofabric", username="demouser", password='poweruser')
-  fabric.on_change(collection="employees", callback=callback_fn)
+  fabric.on_change("employees", callback=callback_fn)
   
 ```
 
@@ -147,7 +147,7 @@ Example to **publish** documents to a stream:
   client = C8Client(protocol='https', host=region, port=443)
   fabric = client.fabric(tenant="demotenant", name="demofabric", username="demouser", password='poweruser')
   stream = fabric.stream()
-  producer = stream.create_producer(collection="demostream", local=False)
+  producer = stream.create_producer("demostream", local=False)
   for i in range(10):
       msg = "Hello from " + region + "("+ str(i) +")"
       producer.send(msg.encode('utf-8'))

--- a/c8/fabric.py
+++ b/c8/fabric.py
@@ -127,7 +127,7 @@ class Fabric(APIWrapper):
         if not collection: 
             raise ValueError('You must specify a collection on which to watch for realtime data!')
 
-        namespace = constants.STREAM_LOCAL_NS_PREFIX + self.fabric_name
+        namespace = constants.STREAM_LOCAL_NS_PREFIX + '.' + self.fabric_name
 
         topic = "persistent://" + self.tenant_name + "/" + namespace + "/" + collection
         subscription_name = self.tenant_name + "-" + self.fabric_name + "-subscription-" + str(random.randint(1, 1000))

--- a/c8/fabric.py
+++ b/c8/fabric.py
@@ -127,9 +127,7 @@ class Fabric(APIWrapper):
         if not collection: 
             raise ValueError('You must specify a collection on which to watch for realtime data!')
 
-        namespace = constants.STREAM_LOCAL_NS_PREFIX + self.tenant_name + '.' + self.fabric_name
-        if self.tenant_name == "_mm":
-            namespace = constants.STREAM_LOCAL_NS_PREFIX + self.fabric_name
+        namespace = constants.STREAM_LOCAL_NS_PREFIX + self.fabric_name
 
         topic = "persistent://" + self.tenant_name + "/" + namespace + "/" + collection
         subscription_name = self.tenant_name + "-" + self.fabric_name + "-subscription-" + str(random.randint(1, 1000))

--- a/c8/fabric.py
+++ b/c8/fabric.py
@@ -127,7 +127,7 @@ class Fabric(APIWrapper):
         if not collection: 
             raise ValueError('You must specify a collection on which to watch for realtime data!')
 
-        namespace = constants.STREAM_LOCAL_NS_PREFIX + '.' + self.fabric_name
+        namespace = constants.STREAM_LOCAL_NS_PREFIX + self.fabric_name
 
         topic = "persistent://" + self.tenant_name + "/" + namespace + "/" + collection
         subscription_name = self.tenant_name + "-" + self.fabric_name + "-subscription-" + str(random.randint(1, 1000))

--- a/c8/stream_collection.py
+++ b/c8/stream_collection.py
@@ -31,6 +31,12 @@ class StreamCollection(APIWrapper):
     CONSUMER_TYPES = enum(EXCLUSIVE=pulsar.ConsumerType.Exclusive, SHARED=pulsar.ConsumerType.Shared,
                           FAILOVER=pulsar.ConsumerType.Failover)
 
+    COMPRESSION_TYPES = enum(LZ4 = pulsar.CompressionType.LZ4, ZLIB = pulsar.CompressionType.ZLib, NONE = pulsar.CompressionType.NONE)
+
+    ROUTING_MODE = enum(SINGLE_PARTITION = pulsar.PartitionsRoutingMode.UseSinglePartition, ROUND_ROBIN_PARTITION = pulsar.PartitionsRoutingMode.RoundRobinDistribution,
+                        CUSTOM_PARTITION = pulsar.PartitionsRoutingMode.CustomPartition
+                        )
+
     def __init__(self, fabric, connection, executor, url, port,
                  operation_timeout_seconds,
                  ):
@@ -84,12 +90,12 @@ class StreamCollection(APIWrapper):
 
     def create_producer(self, stream, local=False, producer_name=None,
                         initial_sequence_id=None, send_timeout_millis=30000,
-                        compression_type=pulsar.CompressionType.NONE,
+                        compression_type=COMPRESSION_TYPES.NONE,
                         max_pending_messages=1000,
                         block_if_queue_full=False, batching_enabled=False,
                         batching_max_messages=1000, batching_max_allowed_size_in_bytes=131072,
                         batching_max_publish_delay_ms=10,
-                        message_routing_mode=pulsar.PartitionsRoutingMode.RoundRobinDistribution
+                        message_routing_mode= ROUTING_MODE.ROUND_ROBIN_PARTITION
                         ):
         """
            Create a new producer on a given stream.

--- a/c8/stream_collection.py
+++ b/c8/stream_collection.py
@@ -144,7 +144,7 @@ class StreamCollection(APIWrapper):
             if local:
                 type_constant = constants.STREAM_LOCAL_NS_PREFIX
 
-            namespace = type_constant + '.' +self.fabric_name
+            namespace = type_constant + self.fabric_name
 
             if self.persistent:
                 topic = "persistent://" + self.tenant_name + "/" + namespace + "/" + stream
@@ -219,7 +219,7 @@ class StreamCollection(APIWrapper):
             if local:
                 type_constant = constants.STREAM_LOCAL_NS_PREFIX
             
-            namespace = type_constant + '.' + self.fabric_name
+            namespace = type_constant + self.fabric_name
 
             if self.persistent:
                 topic = "persistent://" + self.tenant_name + "/" + namespace + "/" + stream
@@ -297,7 +297,7 @@ class StreamCollection(APIWrapper):
             if local:
                 type_constant=constants.STREAM_LOCAL_NS_PREFIX
 
-            namespace = type_constant + '.' + self.fabric_name
+            namespace = type_constant + self.fabric_name
 
             if self.persistent:
                 topic = "persistent://" + self.tenant_name + "/" + namespace + "/" + stream

--- a/c8/stream_collection.py
+++ b/c8/stream_collection.py
@@ -144,7 +144,7 @@ class StreamCollection(APIWrapper):
             if local:
                 type_constant = constants.STREAM_LOCAL_NS_PREFIX
 
-            namespace = type_constant + self.fabric_name
+            namespace = type_constant + '.' +self.fabric_name
 
             if self.persistent:
                 topic = "persistent://" + self.tenant_name + "/" + namespace + "/" + stream
@@ -219,7 +219,7 @@ class StreamCollection(APIWrapper):
             if local:
                 type_constant = constants.STREAM_LOCAL_NS_PREFIX
             
-            namespace = type_constant + self.fabric_name
+            namespace = type_constant + '.' + self.fabric_name
 
             if self.persistent:
                 topic = "persistent://" + self.tenant_name + "/" + namespace + "/" + stream
@@ -297,7 +297,7 @@ class StreamCollection(APIWrapper):
             if local:
                 type_constant=constants.STREAM_LOCAL_NS_PREFIX
 
-            namespace = type_constant + self.fabric_name
+            namespace = type_constant + '.' + self.fabric_name
 
             if self.persistent:
                 topic = "persistent://" + self.tenant_name + "/" + namespace + "/" + stream

--- a/c8/stream_collection.py
+++ b/c8/stream_collection.py
@@ -144,9 +144,8 @@ class StreamCollection(APIWrapper):
             if local:
                 type_constant = constants.STREAM_LOCAL_NS_PREFIX
 
-            namespace = type_constant + self.tenant_name + '.' + self.fabric_name
-            if self.tenant_name == "_mm":
-                namespace = type_constant + self.fabric_name
+            namespace = type_constant + self.fabric_name
+
             if self.persistent:
                 topic = "persistent://" + self.tenant_name + "/" + namespace + "/" + stream
             # else:
@@ -220,9 +219,7 @@ class StreamCollection(APIWrapper):
             if local:
                 type_constant = constants.STREAM_LOCAL_NS_PREFIX
             
-            namespace = type_constant + self.tenant_name + self.fabric_name
-            if self.tenant_name == "_mm":
-                namespace = type_constant + self.fabric_name
+            namespace = type_constant + self.fabric_name
 
             if self.persistent:
                 topic = "persistent://" + self.tenant_name + "/" + namespace + "/" + stream
@@ -300,9 +297,7 @@ class StreamCollection(APIWrapper):
             if local:
                 type_constant=constants.STREAM_LOCAL_NS_PREFIX
 
-            namespace = type_constant + self.tenant_name + '.' + self.fabric_name
-            if self.tenant_name == "_mm":
-                namespace = type_constant + self.fabric_name
+            namespace = type_constant + self.fabric_name
 
             if self.persistent:
                 topic = "persistent://" + self.tenant_name + "/" + namespace + "/" + stream

--- a/docs/stream.rst
+++ b/docs/stream.rst
@@ -42,9 +42,9 @@ Macrometa Streams provide realtime pub/sub messaging capabilities for the Macrom
     #Create a StreamCollection object to invoke stream management functions.
     stream_collection = sys_fabric.stream()
     
-    #Create producer for the given persistent and global/local stream that is created.
-    producer1 = stream_collection.create_producer('test-stream', local=False)
-    producer2 = stream_collection.create_producer('test-stream-1', local=True)
+    #Create producer for the given persistent and global/local stream that is created. You can override default compression types/routing modes as shown.
+    producer1 = stream_collection.create_producer('test-stream', local=False, compression_type = stream_collection.COMPRESSION_TYPES.LZ4)
+    producer2 = stream_collection.create_producer('test-stream-1', local=True, message_routing_mode= stream_collection.ROUTING_MODE.SINGLE_PARTITION)
     
     #send: publish/send a given message over stream in bytes.
     for i in range(10):


### PR DESCRIPTION
## Description
Updated pyC8 to not repeat tenant name in namespace while create producer or subscriber. Had missed few minor issues in stream documentation after persistent changes, so updated the same.

## Type of change
1. Namespace changes
2. Minor stream changes

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested on 2 region federation also tested using smoke test.


## Reviews

@durgagokina 