### PR TITLE
changing pyC8 to move isSystem to the root schema

### DIFF
--- a/c8/fabric.py
+++ b/c8/fabric.py
@@ -174,7 +174,7 @@ class Fabric(APIWrapper):
         def response_handler(resp):
             if not resp.is_success:
                 raise FabricPropertiesError(resp, request)
-            result = resp.body['result']['options']
+            result = resp.body['result']
             result['system'] = result.pop('isSystem')
             return result
 


### PR DESCRIPTION
## Description

Changed pyC8 to move isSystem to the root schema .

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

On a 1-region federation.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Existing and new functional tests pass with my changes

