### PR TITLE
Fix a crash in Client.Tenant()

### DIFF
--- a/c8/connection.py
+++ b/c8/connection.py
@@ -46,11 +46,6 @@ class Connection(object):
         self._token = token
         self._apikey = apikey
         self._header = ''
-        # # Set the auth credentials depending on tenant name
-        # if self._tenant_name == '_mm':
-        #     self._auth = (username, password)
-        # else:
-        #     self._auth = (self._tenant_name + '.' + username, password)
 
         # Construct the URL prefix in the required format.
         #if not fabric_name:

--- a/c8/tenant.py
+++ b/c8/tenant.py
@@ -88,7 +88,7 @@ class Tenant(APIWrapper):
         self._conn.set_url_prefix(proto + '//' + rema )
         data = {"tenant": self.tenant_name}
         data['email'] = self._conn._email
-        data['password'] = self._conn._auth[1]
+        data['password'] = self._conn._password
         request = Request(
             method='post',
             endpoint='/_open/auth',


### PR DESCRIPTION
## Description

Fixes Macrometacorp/C8Platform#1995

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The script provided by the reporter:

```py
from c8 import C8Client

# GDN credentials
EMAIL = 'hidden'
PASSWD = 'hidden'

REGION = 'hidden.eng.macrometa.io'
FABRIC = '_system'

# GDN client
client = C8Client(protocol='https', host=REGION, port=443, email=EMAIL, password=PASSWD, geofabric=FABRIC)
tenant = client.tenant(email=EMAIL, password=PASSWD)
tenant.get_auth_token_from_server()
print(tenant.auth_token)
```

**Test Configuration**:

* C8 Version: Not sure, but this is a purely client-side bug.

## Reviews

- [ ] @davidlubomirov 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added new functional tests that prove my fix is effective or that my feature works
- [ ] Existing and new functional tests pass with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
