### PR TITLE
boolean has_collection()

### DIFF
--- a/c8/fabric.py
+++ b/c8/fabric.py
@@ -590,11 +590,7 @@ class Fabric(APIWrapper):
         :return: True if collection exists, False otherwise.
         :rtype: bool
         """
-        col = any(col['name'] == name for col in self.collections())
-        if not col:
-            raise Exception("Collection not found")
-        else:
-            return col
+        return any(col['name'] == name for col in self.collections())
 
     def collections(self, collectionModel=None):
         """Return the collections in the fabric.


### PR DESCRIPTION
has_collection() doesn't have to raise an exception, its purpose is to be used in conditions.

related:

- Macrometacorp/C8Platform#1622
- Macrometacorp/pyC8#61