### PR TITLE
quit on non-dict documents

### DIFF
--- a/c8/collection.py
+++ b/c8/collection.py
@@ -256,6 +256,8 @@ class Collection(APIWrapper):
         :return: Document body with "_key" field if it has "_id" field.
         :rtype: dict
         """
+        if not isinstance(body, dict):
+            raise DocumentParseError("Document is not a dict")
         if '_id' in body and '_key' not in body:
             doc_id = self._validate_id(body['_id'])
             body = body.copy()


### PR DESCRIPTION
## Description

Raises an exception upon trying to insert a list of documents some of which are not dictionaries.
If even one of them is not, the whole insert fails atomically.

Fixes Macrometacorp/C8Platform#2615