### PR TITLE
Fixing Timeout Exception to "WebSocketTimeoutException"

### DIFF
--- a/c8/fabric.py
+++ b/c8/fabric.py
@@ -6,7 +6,6 @@ import base64
 
 import websocket
 
-from websocket import _exceptions
 from c8.api import APIWrapper
 from c8.c8ql import C8QL
 from c8.keyvalue import KV
@@ -174,7 +173,7 @@ class Fabric(APIWrapper):
                 data = base64.b64decode(msg['payload'])
                 ws.send(json.dumps({'messageId': msg['messageId']}))
                 callback(data)
-        except _exceptions.WebSocketTimeoutException:
+        except websocket.WebSocketTimeoutException:
             pass
         except Exception as e:
             print(e)

--- a/c8/fabric.py
+++ b/c8/fabric.py
@@ -6,6 +6,7 @@ import base64
 
 import websocket
 
+from websocket import _exceptions
 from c8.api import APIWrapper
 from c8.c8ql import C8QL
 from c8.keyvalue import KV
@@ -173,7 +174,7 @@ class Fabric(APIWrapper):
                 data = base64.b64decode(msg['payload'])
                 ws.send(json.dumps({'messageId': msg['messageId']}))
                 callback(data)
-        except TimeoutError:
+        except _exceptions.WebSocketTimeoutException:
             pass
         except Exception as e:
             print(e)


### PR DESCRIPTION
## Description
The timeout exception received in case of a websocket timeout is "WebSocketTimeoutException" and not "TimeoutError"
https://macrometa.com/docs/collections/documents/tutorials/using-realtime-updates#code-sample if we run this code we will receive the following error:
"The read operation timed out" 
This is because the timeout error is not correctly handled hence I have fixed the same here.

Thanks,
Koshy

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
https://macrometa.com/docs/collections/documents/tutorials/using-realtime-updates#code-sample
Run the code with your credentials and apikey you will get a "the read operation timed out error" this is because the timeout exception is wrongly handled in the above code.

**Test Configuration**:
after doing this change you can just run build locally python3 setup.py build and then run the code https://macrometa.com/docs/collections/documents/tutorials/using-realtime-updates#code-sample
Run the code with your credentials and apikey 

* C8 Version:

## Reviews

Please identify two developers to review this change

- [x] @ricardo-macrometa 
- [x] @warchiefx

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added new functional tests that prove my fix is effective or that my feature works
- [x] Existing and new functional tests pass with my changes
- [x] Any dependent changes have been merged and published in downstream modules
