### PR TITLE
Adding test_apikeys.py and updating test_permission.py

### DIFF
--- a/c8/apikeys.py
+++ b/c8/apikeys.py
@@ -5,6 +5,7 @@ import json
 
 from c8.exceptions import (
     CreateAPIKey,
+    GetAPIKeys,
     RemoveAPIKey,
     ListDataBases,
     DataBaseAccessLevel,
@@ -19,7 +20,11 @@ from c8.exceptions import (
     ClearStreamAccessLevel,
     SetBillingAccessLevel,
     BillingAccessLevel,
-    ClearBillingAccessLevel
+    ClearBillingAccessLevel,
+    GetAttributes,
+    UpdateAttributes,
+    RemoveAllAttributes,
+    RemoveAttribute
 )
 
 class APIKeys(APIWrapper):
@@ -58,9 +63,28 @@ class APIKeys(APIWrapper):
             else:
                 return resp.body
                 
-        return self._execute(request, response_handler)
+        return self._execute(request, response_handler, customPrefix="/_api")
 
-    
+    def get_api_key(self):
+        """Fetch details of an api key.
+        :param keyid: Id of the key to be fetched.
+        :type name: str | unicode
+        :return: Details of the api key.
+        :rtype: dict
+        :raise c8.exceptions.GetAPIKeys: If request fails.
+        """
+        request = Request(
+            method='get',
+            endpoint='/key/{}'.format(self._keyid),
+        )
+
+        def response_handler(resp):
+            if not resp.is_success:
+                raise GetAPIKeys(resp, request)
+            return resp.body
+
+        return self._execute(request, response_handler, customPrefix="/_api")
+
     def remove_api_key(self):
         """Removes an api key.
         :param keyid: Id of the key to be created.
@@ -83,7 +107,7 @@ class APIKeys(APIWrapper):
                 else:
                     return False
                 
-        return self._execute(request, response_handler)
+        return self._execute(request, response_handler, customPrefix="/_api")
 
     
     def list_accessible_databases(self):
@@ -104,7 +128,7 @@ class APIKeys(APIWrapper):
             else:
                 return resp.body['result']
                 
-        return self._execute(request, response_handler)
+        return self._execute(request, response_handler, customPrefix="/_api")
 
     
     def get_database_access_level(self, databasename):
@@ -128,7 +152,7 @@ class APIKeys(APIWrapper):
             else:
                 return resp.body['result']
                 
-        return self._execute(request, response_handler)
+        return self._execute(request, response_handler, customPrefix="/_api")
 
     
     def set_database_access_level(self, databasename, grant='ro'):
@@ -159,7 +183,7 @@ class APIKeys(APIWrapper):
             else:
                 return resp.body
                 
-        return self._execute(request, response_handler)
+        return self._execute(request, response_handler, customPrefix="/_api")
 
     
     def clear_database_access_level(self, databasename):
@@ -187,9 +211,35 @@ class APIKeys(APIWrapper):
                 elif resp.body['error'] is True:
                     return False
                 
-        return self._execute(request, response_handler)
+        return self._execute(request, response_handler, customPrefix="/_api")
 
 #------------------------------------------------------------------------
+
+    def list_accessible_collections(self, databasename='_system', full=False):
+        """Fetch all the accessible collections in a database.
+
+        :param databasename: Name of the database
+        :type databasename: string
+        :param full: Return the full set of access levels for all collections.
+        :type full: boolean
+        :return: AccessLevel of a db.
+        :rtype: string
+        :raise c8.exceptions.CollectionAccessLevel: If request fails.
+        """
+        request = Request(
+            method='get',
+            endpoint='/key/{}/database/{}/collection?full={}'.format(self._keyid,
+                                                                     databasename,
+                                                                     full),
+        )
+
+        def response_handler(resp):
+            if not resp.is_success:
+                raise CollectionAccessLevel(resp, request)
+            else:
+                return resp.body['result']
+
+        return self._execute(request, response_handler, customPrefix="/_api")
 
     def get_collection_access_level(self, collection_name, databasename='_system'):
         """Fetch the collection access level for a specific collection in a database.
@@ -215,7 +265,7 @@ class APIKeys(APIWrapper):
             else:
                 return resp.body['result']
                 
-        return self._execute(request, response_handler)
+        return self._execute(request, response_handler, customPrefix="/_api")
 
     
     def set_collection_access_level(self, collection_name, databasename='_system',
@@ -251,7 +301,7 @@ class APIKeys(APIWrapper):
             else:
                 return resp.body
                 
-        return self._execute(request, response_handler)
+        return self._execute(request, response_handler, customPrefix="/_api")
 
     
     def clear_collection_access_level(self, collection_name, databasename='_system'):
@@ -283,7 +333,7 @@ class APIKeys(APIWrapper):
                 elif resp.body['error'] is True:
                     return False
                 
-        return self._execute(request, response_handler)
+        return self._execute(request, response_handler, customPrefix="/_api")
 
 #---------------------------------------------------------------------------
 
@@ -311,7 +361,7 @@ class APIKeys(APIWrapper):
             else:
                 return resp.body['result']
                 
-        return self._execute(request, response_handler)
+        return self._execute(request, response_handler, customPrefix="/_api")
 
     
     def get_stream_access_level(self, streamname, databasename='_system', local=False):
@@ -344,7 +394,7 @@ class APIKeys(APIWrapper):
             else:
                 return resp.body['result']
                 
-        return self._execute(request, response_handler)
+        return self._execute(request, response_handler, customPrefix="/_api")
 
     
     def set_stream_access_level(self, streamname, databasename='_system', grant='ro', local=False):
@@ -386,7 +436,7 @@ class APIKeys(APIWrapper):
             else:
                 return resp.body
                 
-        return self._execute(request, response_handler)
+        return self._execute(request, response_handler, customPrefix="/_api")
 
     
     def clear_stream_access_level(self, streamname, databasename='_system', local=False):
@@ -426,7 +476,7 @@ class APIKeys(APIWrapper):
                 elif resp.body['error'] is True:
                     return False
                 
-        return self._execute(request, response_handler)
+        return self._execute(request, response_handler, customPrefix="/_api")
 
 #-----------------------------------------------------------------------------
 
@@ -448,7 +498,7 @@ class APIKeys(APIWrapper):
             else:
                 return resp.body['result']
                 
-        return self._execute(request, response_handler)
+        return self._execute(request, response_handler, customPrefix="/_api")
 
     
     def set_billing_access_level(self, grant='ro'):
@@ -477,7 +527,7 @@ class APIKeys(APIWrapper):
             else:
                 return resp.body
                 
-        return self._execute(request, response_handler)
+        return self._execute(request, response_handler, customPrefix="/_api")
 
     
     def clear_billing_access_level(self):
@@ -500,4 +550,95 @@ class APIKeys(APIWrapper):
             else:
                 return resp.body
                 
-        return self._execute(request, response_handler)
+        return self._execute(request, response_handler, customPrefix="/_api")
+
+#-----------------------------------------------------------------------------
+
+    def get_attributes(self):
+        """Fetch the list of attributes.
+
+        :returns: All attributes for the apikey.
+        :rtype: dict
+        :raise c8.exceptions.GetAttributes: If request fails.
+        """
+        request = Request(
+            method='get',
+            endpoint='/key/{}/attributes'.format(self._keyid),
+        )
+
+        def response_handler(resp):
+            if not resp.is_success:
+                raise GetAttributes(resp, request)
+            else:
+                return resp.body
+                
+        return self._execute(request, response_handler, customPrefix="/_api")
+
+    
+    def update_attributes(self, attributes):
+        """Update the list of attributes.
+
+        :param attributes: The key-value pairs of attributes with values that needs to be updated.
+        :type attributes: dict
+        :returns: The updated attributes.
+        :rtype: Object
+        :raise c8.exceptions.UpdateAttributes: If request fails.
+        """
+        request = Request(
+            method='put',
+            endpoint='/key/{}/attributes'.format(self._keyid),
+            data=attributes
+        )
+
+        def response_handler(resp):
+            if not resp.is_success:
+                raise UpdateAttributes(resp, request)
+            else:
+                return resp.body
+                
+        return self._execute(request, response_handler, customPrefix="/_api")
+
+    
+    def remove_all_attributes(self):
+        """Remove all attributes.
+
+        :returns: All attributes for the apikey.
+        :rtype: dict
+        :raise c8.exceptions.RemoveAllAttributes: If request fails.
+        """
+        request = Request(
+            method='delete',
+            endpoint='/key/{}/attributes/truncate'.format(self._keyid),
+           
+        )
+
+        def response_handler(resp):
+            if not resp.is_success:
+                raise RemoveAllAttributes(resp, request)
+            else:
+                return resp.body
+                
+        return self._execute(request, response_handler, customPrefix="/_api")
+
+    def remove_attribute(self, attributeid):
+
+        """Remove the specified attribute.
+
+        :returns: All attributes for the apikey.
+        :rtype: dict
+        :raise c8.exceptions.RemoveAllAttributes: If request fails.
+        """
+        request = Request(
+            method='delete',
+            endpoint='/key/{}/attributes/{}'.format(self._keyid, attributeid),
+           
+        )
+
+        def response_handler(resp):
+            if not resp.is_success:
+                raise RemoveAttribute(resp, request)
+            else:
+                return resp.body
+                
+        return self._execute(request, response_handler, customPrefix="/_api")
+    

--- a/c8/apikeys.py
+++ b/c8/apikeys.py
@@ -213,7 +213,6 @@ class APIKeys(APIWrapper):
                 
         return self._execute(request, response_handler, customPrefix="/_api")
 
-#------------------------------------------------------------------------
 
     def list_accessible_collections(self, databasename='_system', full=False):
         """Fetch all the accessible collections in a database.
@@ -335,7 +334,6 @@ class APIKeys(APIWrapper):
                 
         return self._execute(request, response_handler, customPrefix="/_api")
 
-#---------------------------------------------------------------------------
 
     def list_accessible_streams(self, databasename='_system', full=False):
         """Fetch the list of streams available to the specified keyid.
@@ -478,7 +476,6 @@ class APIKeys(APIWrapper):
                 
         return self._execute(request, response_handler, customPrefix="/_api")
 
-#-----------------------------------------------------------------------------
 
     def get_billing_access_level(self):
         """Fetch the billing access level.
@@ -552,7 +549,6 @@ class APIKeys(APIWrapper):
                 
         return self._execute(request, response_handler, customPrefix="/_api")
 
-#-----------------------------------------------------------------------------
 
     def get_attributes(self):
         """Fetch the list of attributes.

--- a/c8/apikeys.py
+++ b/c8/apikeys.py
@@ -18,7 +18,7 @@ from c8.exceptions import (
     SetStreamAccessLevel,
     ClearStreamAccessLevel,
     SetBillingAccessLevel,
-    BillingAcessLevel,
+    BillingAccessLevel,
     ClearBillingAccessLevel
 )
 
@@ -444,7 +444,7 @@ class APIKeys(APIWrapper):
 
         def response_handler(resp):
             if not resp.is_success:
-                raise BillingAcessLevel(resp, request)
+                raise BillingAccessLevel(resp, request)
             else:
                 return resp.body['result']
                 

--- a/c8/client.py
+++ b/c8/client.py
@@ -2004,7 +2004,7 @@ class C8Client(object):
         :type databasename: str | unicode
         :returns: Access Details
         :rtype: string
-        :raise c8.exceptions.DataBaseError: If request fails.
+        :raise c8.exceptions.GetDataBaseAccessLevel: If request fails.
         """
         return self._tenant.get_database_access_level_user(username=username,
                                                            databasename=databasename)
@@ -2021,7 +2021,7 @@ class C8Client(object):
         :type databasename: str | unicode
         :returns: Object containing database details
         :rtype: object
-        :raise c8.exceptions.DataBaseError: If request fails.
+        :raise c8.exceptions.ClearDataBaseAccessLevel: If request fails.
         """
         return self._tenant.remove_database_access_level_user(username=username,
                                                               databasename=databasename)
@@ -2042,11 +2042,27 @@ class C8Client(object):
         :type grant: string
         :returns: Object containing database details
         :rtype: object
-        :raise c8.exceptions.DataBaseError: If request fails.
+        :raise c8.exceptions.SetDataBaseAccessLevel: If request fails.
         """
         return self._tenant.set_database_access_level_user(username=username,
                                                            databasename=databasename,
                                                            grant=grant)
+
+    # client.list_accessible_collections_user
+
+    def list_accessible_collections_user(self, username, databasename='_system'):
+        """Fetch the collection access level for a specific collection in a database.
+
+        :param username: Name of the user
+        :type username: string
+        :param databasename: Name of the database
+        :type databasename: string
+        :returns: Fetch the list of collections access level for a specific user.
+        :rtype: string
+        :raise c8.exceptions.CollectionAccessLevel: If request fails.
+        """
+        return self._tenant.list_accessible_collections_user(username=username,
+                                                             databasename=databasename)
 
     # client.get_collection_access_level_user
 
@@ -2223,7 +2239,7 @@ class C8Client(object):
         :rtype: Object
         :raise c8.exceptions.SetBillingAccessLevel: If request fails.
         """
-        return self._tenant.set_billing_access_level(username=username, grant=grant)
+        return self._tenant.set_billing_access_level_user(username=username, grant=grant)
 
     # client.clear_billing_access_level
 
@@ -2235,7 +2251,7 @@ class C8Client(object):
         :rtype: booleaan
         :raise c8.exceptions.ClearBillingAccessLevel: If request fails.
         """
-        return self._tenant.clear_billing_access_level(username=username)
+        return self._tenant.clear_billing_access_level_user(username=username)
 
     # client.get_attributes_user
 
@@ -2259,7 +2275,7 @@ class C8Client(object):
         :type attributes: dict
         :returns: The updated attributes.
         :rtype: Object
-        :raise c8.exceptions.GetAUpdateAttributesttributes: If request fails.
+        :raise c8.exceptions.UpdateAttributes: If request fails.
         """
         return self._tenant.update_attributes_user(username=username,
                                                    attributes=attributes)

--- a/c8/client.py
+++ b/c8/client.py
@@ -2050,19 +2050,22 @@ class C8Client(object):
 
     # client.list_accessible_collections_user
 
-    def list_accessible_collections_user(self, username, databasename='_system'):
+    def list_accessible_collections_user(self, username, databasename='_system', full=False):
         """Fetch the collection access level for a specific collection in a database.
 
         :param username: Name of the user
         :type username: string
         :param databasename: Name of the database
         :type databasename: string
+        :param full: Return the full set of access levels for all collections.
+        :type full: boolean
         :returns: Fetch the list of collections access level for a specific user.
         :rtype: string
         :raise c8.exceptions.CollectionAccessLevel: If request fails.
         """
         return self._tenant.list_accessible_collections_user(username=username,
-                                                             databasename=databasename)
+                                                             databasename=databasename,
+                                                             full=full)
 
     # client.get_collection_access_level_user
 
@@ -2476,6 +2479,12 @@ class C8Client(object):
     def list_all_api_keys(self):
         return self._fabric.list_all_api_keys()
 
+    # client.get_api_key
+
+    def get_api_key(self, keyid):
+        _apiKeys = self._fabric.api_keys(keyid)
+        return _apiKeys.get_api_key()
+
     # client.remove_api_key
 
     def remove_api_key(self, keyid):
@@ -2493,7 +2502,6 @@ class C8Client(object):
     def get_database_access_level(self, keyid, databasename):
         """Fetch the database access level for a specific database.
 
-
         :param databasename: Name of the database
         :type databasename: string
         :returns: AccessLevel of a db.
@@ -2510,6 +2518,10 @@ class C8Client(object):
     def clear_database_access_level(self, keyid, databasename):
         _apiKeys = self._fabric.api_keys(keyid)
         return _apiKeys.clear_database_access_level(databasename)
+
+    def list_accessible_collections(self, keyid, databasename='_system', full=False):
+        _apiKeys = self._fabric.api_keys(keyid)
+        return _apiKeys.list_accessible_collections(databasename, full)
 
     def get_collection_access_level(self, keyid, collection_name,
                                     databasename='_system'):
@@ -2559,6 +2571,22 @@ class C8Client(object):
     def clear_billing_access_level(self, keyid):
         _apiKeys = self._fabric.api_keys(keyid)
         return _apiKeys.clear_billing_access_level()
+
+    def get_attributes(self, keyid):
+        _apiKeys = self._fabric.api_keys(keyid)
+        return _apiKeys.get_attributes()
+
+    def update_attributes(self, keyid, attributes):
+        _apiKeys = self._fabric.api_keys(keyid)
+        return _apiKeys.update_attributes(attributes)
+
+    def remove_all_attributes(self, keyid):
+        _apiKeys = self._fabric.api_keys(keyid)
+        return _apiKeys.remove_all_attributes()
+
+    def remove_attribute(self, keyid, attributeid):
+        _apiKeys = self._fabric.api_keys(keyid)
+        return _apiKeys.remove_attribute(attributeid)
 
     def set_search(self, collection, enable, field):
         """Set search capability of a collection (enabling or disabling it). 

--- a/c8/exceptions.py
+++ b/c8/exceptions.py
@@ -675,7 +675,7 @@ class ClearStreamAccessLevel(C8ServerError):
 class ListStreams(C8ServerError):
     """Failed to fetch the streams for the specified key"""
 
-class BillingAcessLevel(C8ServerError):
+class BillingAccessLevel(C8ServerError):
     """Failed to fetch the billing access level"""
 
 class SetBillingAccessLevel(C8ServerError):

--- a/c8/fabric.py
+++ b/c8/fabric.py
@@ -1351,7 +1351,7 @@ class Fabric(APIWrapper):
                 raise GetAPIKeys(resp, request)
             else:
                 return resp.body['result']
-        return self._execute(request, response_handler)
+        return self._execute(request, response_handler, customPrefix="/_api")
 
     ##############################
     # Search, View and Analyzers #

--- a/c8/fabric.py
+++ b/c8/fabric.py
@@ -996,7 +996,7 @@ class Fabric(APIWrapper):
         def response_handler(resp):
            code = resp.status_code
            if resp.is_success:
-               return resp.body['result']
+               return True
            elif code == 403:
                raise StreamPermissionError(resp, request)
            elif code == 412:

--- a/c8/tenant.py
+++ b/c8/tenant.py
@@ -25,6 +25,7 @@ from c8.exceptions import (
     DataBaseError,
     GetDataBaseAccessLevel,
     SetDataBaseAccessLevel,
+    ClearDataBaseAccessLevel,
     SetCollectionAccessLevel,
     CollectionAccessLevel,
     ClearCollectionAccessLevel,
@@ -33,7 +34,7 @@ from c8.exceptions import (
     SetStreamAccessLevel,
     ClearStreamAccessLevel,
     SetBillingAccessLevel,
-    BillingAcessLevel,
+    BillingAccessLevel,
     ClearBillingAccessLevel,
     GetAttributes,
     UpdateAttributes,
@@ -596,7 +597,7 @@ class Tenant(APIWrapper):
         :type databasename: str | unicode
         :returns: Access Details
         :rtype: string
-        :raise c8.exceptions.DataBaseError: If request fails.
+        :raise c8.exceptions.GetDataBaseAccessLevel: If request fails.
         """
         request = Request(
             method='get',
@@ -606,7 +607,7 @@ class Tenant(APIWrapper):
         def response_handler(resp):
             if resp.is_success:
                return resp.body['result']
-            raise DataBaseError(resp, request)
+            raise GetDataBaseAccessLevel(resp, request)
 
         return self._execute(request, response_handler, customPrefix="/_api")
 
@@ -620,7 +621,7 @@ class Tenant(APIWrapper):
         :type databasename: str | unicode
         :returns: Object containing database details
         :rtype: object
-        :raise c8.exceptions.DataBaseError: If request fails.
+        :raise c8.exceptions.ClearDataBaseAccessLevel: If request fails.
         """
         request = Request(
             method='delete',
@@ -629,8 +630,8 @@ class Tenant(APIWrapper):
 
         def response_handler(resp):
             if resp.is_success:
-               return resp.body
-            raise DataBaseError(resp, request)
+               return True
+            raise ClearDataBaseAccessLevel(resp, request)
 
         return self._execute(request, response_handler, customPrefix="/_api")
 
@@ -648,7 +649,7 @@ class Tenant(APIWrapper):
         :type grant: string
         :returns: Object containing database details
         :rtype: object
-        :raise c8.exceptions.DataBaseError: If request fails.
+        :raise c8.exceptions.SetDataBaseAccessLevel: If request fails.
         """
         request = Request(
             method='put',
@@ -661,10 +662,34 @@ class Tenant(APIWrapper):
         def response_handler(resp):
             if resp.is_success:
                return resp.body
-            raise DataBaseError(resp, request)
+            raise SetDataBaseAccessLevel(resp, request)
 
         return self._execute(request, response_handler, customPrefix="/_api")
 
+    def list_accessible_collections_user(self, username, databasename='_system'):
+        """Fetch the collection access level for a specific collection in a database.
+
+        :param username: Name of the user
+        :type username: string
+        :param databasename: Name of the database
+        :type databasename: string
+        :returns: Fetch the list of collections access level for a specific user.
+        :rtype: string
+        :raise c8.exceptions.CollectionAccessLevel: If request fails.
+        """
+        request = Request(
+            method='get',
+            endpoint='/user/{}/database/{}/collection/'.format(username,
+                                                               databasename),
+        )
+
+        def response_handler(resp):
+            if not resp.is_success:
+                raise CollectionAccessLevel(resp, request)
+            else:
+                return resp.body['result']
+                
+        return self._execute(request, response_handler, customPrefix="/_api")
 
     def get_collection_access_level_user(self, username, collection_name, databasename='_system'):
         """Fetch the collection access level for a specific collection in a database.
@@ -893,7 +918,7 @@ class Tenant(APIWrapper):
 
         def response_handler(resp):
             if not resp.is_success:
-                raise BillingAcessLevel(resp, request)
+                raise BillingAccessLevel(resp, request)
             else:
                 return resp.body['result']
                 
@@ -979,7 +1004,7 @@ class Tenant(APIWrapper):
         :type attributes: dict
         :returns: The updated attributes.
         :rtype: Object
-        :raise c8.exceptions.GetAUpdateAttributesttributes: If request fails.
+        :raise c8.exceptions.UpdateAttributes: If request fails.
         """
         request = Request(
             method='put',

--- a/c8/tenant.py
+++ b/c8/tenant.py
@@ -666,21 +666,24 @@ class Tenant(APIWrapper):
 
         return self._execute(request, response_handler, customPrefix="/_api")
 
-    def list_accessible_collections_user(self, username, databasename='_system'):
+    def list_accessible_collections_user(self, username, databasename='_system', full=False):
         """Fetch the collection access level for a specific collection in a database.
 
         :param username: Name of the user
         :type username: string
         :param databasename: Name of the database
         :type databasename: string
+        :param full: Return the full set of access levels for all collections.
+        :type full: boolean
         :returns: Fetch the list of collections access level for a specific user.
         :rtype: string
         :raise c8.exceptions.CollectionAccessLevel: If request fails.
         """
         request = Request(
             method='get',
-            endpoint='/user/{}/database/{}/collection/'.format(username,
-                                                               databasename),
+            endpoint='/user/{}/database/{}/collection?full={}'.format(username,
+                                                                      databasename,
+                                                                      full),
         )
 
         def response_handler(resp):
@@ -1025,8 +1028,8 @@ class Tenant(APIWrapper):
         """Remove all attributes of the specified user.
 
         :returns: True if operation successful.
-        :rtype: booleaan
-        :raise c8.exceptions.RemoveAllAttributes: If request fails.
+        :returns: All attributes for the specified user.
+        :rtype: dict
         """
         request = Request(
             method='delete',
@@ -1047,8 +1050,8 @@ class Tenant(APIWrapper):
 
         :param attributeid: Name of the attribute
         :type attributeid: string
-        :returns: True if operation successful.
-        :rtype: booleaan
+        :returns: All attributes for the specified user.
+        :rtype: dict
         :raise c8.exceptions.RemoveAttribute: If request fails.
         """
         request = Request(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,12 @@ def pytest_unconfigure(config):  # pragma: no cover
         if col_name.startswith('test_collection'):
             sys_fabric.delete_collection(col_name, ignore_missing=True)
 
+   # Remove all test streams.
+    for stream in sys_fabric.streams():
+        stream_name = stream['name']
+        if stream_name.startswith('c8globals.test_stream'):
+            sys_fabric.delete_stream(stream_name)
+
 
 # noinspection PyProtectedMember
 def pytest_generate_tests(metafunc):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,6 +129,11 @@ def pytest_unconfigure(config):  # pragma: no cover
         if stream_name.startswith('c8globals.test_stream'):
             sys_fabric.delete_stream(stream_name)
 
+   # Remove all test apikeys.
+    for apikey in sys_fabric.list_all_api_keys():
+        apikey_id = apikey['keyid']
+        if apikey_id.startswith('test_apikey_id'):
+            client.remove_api_key(apikey_id)
 
 # noinspection PyProtectedMember
 def pytest_generate_tests(metafunc):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -30,12 +30,20 @@ def generate_col_name():
     return 'test_collection_{}'.format(uuid4().hex)
 
 def generate_stream_name():
-    """Generate and return a random collection name.
+    """Generate and return a random stream name.
 
-    :return: Random collection name.
+    :return: Random stream name.
     :rtype: str | unicode
     """
     return 'test_stream_{}'.format(uuid4().hex)
+
+def generate_apikey_id():
+    """Generate and return a random apikey id.
+
+    :return: Random apikey id
+    :rtype: str | unicode
+    """
+    return 'test_apikey_id_{}'.format(str(uuid4().hex)[:10])
 
 def generate_graph_name():
     """Generate and return a random graph name.

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -29,6 +29,13 @@ def generate_col_name():
     """
     return 'test_collection_{}'.format(uuid4().hex)
 
+def generate_stream_name():
+    """Generate and return a random collection name.
+
+    :return: Random collection name.
+    :rtype: str | unicode
+    """
+    return 'test_stream_{}'.format(uuid4().hex)
 
 def generate_graph_name():
     """Generate and return a random graph name.

--- a/tests/test_apikeys.py
+++ b/tests/test_apikeys.py
@@ -1,0 +1,344 @@
+from __future__ import absolute_import, unicode_literals
+import time
+import websocket
+from c8.exceptions import (
+    CollectionCreateError,
+    CollectionListError,
+    CreateAPIKey,
+    GetAPIKeys,
+    RemoveAPIKey,
+    ListDataBases,
+    DataBaseAccessLevel,
+    SetDataBaseAccessLevel,
+    ClearDataBaseAccessLevel,
+    SetCollectionAccessLevel,
+    CollectionAccessLevel,
+    ClearCollectionAccessLevel,
+    DocumentInsertError,
+    DocumentGetError,
+    ListStreams,
+    StreamAccessLevel,
+    SetStreamAccessLevel,
+    ClearStreamAccessLevel,
+    SetBillingAccessLevel,
+    BillingAccessLevel,
+    ClearBillingAccessLevel,
+    GetAttributes,
+    UpdateAttributes,
+    RemoveAllAttributes,
+    RemoveAttribute
+)
+from tests.helpers import (
+    assert_raises,
+    extract,
+    generate_col_name,
+    generate_stream_name,
+    generate_fabric_name,
+    generate_apikey_id
+)
+
+def test_apikey_management(client):
+    # Create apikey
+    apikey_id = generate_apikey_id()
+    resp = client.create_api_key(apikey_id)
+    assert resp['error'] == False
+    apikey = resp['key']
+
+    assert apikey_id in extract('keyid', client.list_all_api_keys())
+
+    resp = client.get_api_key(apikey_id)
+    assert resp['error'] == False
+
+    user = client.tenant(apikey=apikey)
+    sys_fabric = user.useFabric("_system")
+    apiKeys = sys_fabric.api_keys(apikey_id)
+
+    tst_fabric_name = generate_fabric_name()
+    col_name_1 = generate_col_name()
+    col_name_2 = generate_col_name()
+
+    sys_fabric.create_fabric(
+        name=tst_fabric_name,
+        users=['root']
+    )
+
+    # Test update permission (fabric level) to none and verify access
+    resp = apiKeys.set_database_access_level(tst_fabric_name, 'none')
+    assert resp['error'] == False
+    assert apiKeys.get_database_access_level(tst_fabric_name) == 'none'
+
+    tst_fabric = user.useFabric(tst_fabric_name)
+    with assert_raises(CollectionCreateError) as err:
+        tst_fabric.create_collection(col_name_1)
+    assert err.value.http_code == 401
+    with assert_raises(CollectionListError) as err:
+        tst_fabric.collections()
+    assert err.value.http_code == 401
+
+    # Test update permission (fabric level) to read only and verify access
+    resp = apiKeys.set_database_access_level(tst_fabric_name, 'ro')
+    assert resp['error'] == False
+    assert apiKeys.get_database_access_level(tst_fabric_name) == 'ro'
+    with assert_raises(CollectionCreateError) as err:
+        tst_fabric.create_collection(col_name_1)
+    assert err.value.http_code == 403
+    assert col_name_1 not in extract('name', tst_fabric.collections())
+
+    resp = apiKeys.list_accessible_databases()
+    assert resp['_system'] == 'rw'
+    assert resp[tst_fabric_name] == 'ro'
+
+    # Test reset permission (fabric level) and verify access
+    assert apiKeys.clear_database_access_level(tst_fabric_name) is True
+    assert apiKeys.get_database_access_level(tst_fabric_name) == 'none'
+    with assert_raises(CollectionCreateError) as err:
+        tst_fabric.create_collection(col_name_1)
+    assert err.value.http_code == 401
+    with assert_raises(CollectionListError) as err:
+        tst_fabric.collections()
+    assert err.value.http_code == 401
+
+    # Test update permission (fabric level) and verify access
+    apiKeys.set_database_access_level(tst_fabric_name, 'rw')
+    assert apiKeys.get_database_access_level(tst_fabric_name) == 'rw'
+    assert tst_fabric.create_collection(col_name_1) is not None
+    assert col_name_1 in extract('name', tst_fabric.collections())
+    assert tst_fabric.create_collection(col_name_2) is not None
+    assert col_name_2 in extract('name', tst_fabric.collections())
+
+    col_1 = tst_fabric.collection(col_name_1)
+    col_2 = tst_fabric.collection(col_name_2)
+
+    resp = apiKeys.list_accessible_collections(tst_fabric_name)
+    assert resp[col_name_1] == 'rw'
+    assert resp[col_name_2] == 'rw'
+
+    # Verify that user has read and write access to the collection
+    assert isinstance(col_1.insert({}), dict)
+    assert isinstance(col_2.insert({}), dict)
+
+    # Test update permission (collection level) to read only and verify access
+    apiKeys.set_collection_access_level(col_name_1, tst_fabric_name, 'ro')
+    assert apiKeys.get_collection_access_level(col_name_1, tst_fabric_name) == 'ro'
+    assert isinstance(col_1.export(), list)
+    with assert_raises(DocumentInsertError) as err:
+        col_1.insert({})
+    assert err.value.http_code == 403
+    assert isinstance(col_2.insert({}), dict)
+
+    # Test update permission (collection level) to none and verify access
+    resp = apiKeys.set_collection_access_level(col_name_1, tst_fabric_name, 'none')
+    assert resp['error'] == False
+    with assert_raises(DocumentGetError) as err:
+        col_1.export()
+    assert err.value.http_code == 500
+    with assert_raises(DocumentInsertError) as err:
+        col_1.insert({})
+    assert err.value.http_code == 403
+    assert isinstance(col_2.export(), list)
+    assert isinstance(col_2.insert({}), dict)
+
+    # Test reset permission (collection level)
+    assert apiKeys.clear_collection_access_level(col_name_1, tst_fabric_name) is True
+    assert apiKeys.get_collection_access_level(col_name_1, tst_fabric_name) == 'rw'
+    assert isinstance(col_1.insert({}), dict)
+    assert isinstance(col_2.insert({}), dict)
+
+    # Test permissions (stream level)
+    stream_name_1 = generate_stream_name()
+    stream_name_2 = generate_stream_name()
+    tst_fabric.create_stream(stream_name_1)
+    tst_fabric.create_stream(stream_name_2)
+
+    stream_1 = f'c8globals.{stream_name_1}'
+    stream_2 = f'c8globals.{stream_name_2}'
+
+    # Test update permission (stream level) to read only and read write and verify access
+    apiKeys.set_stream_access_level(stream_1, tst_fabric_name, 'ro')
+    assert apiKeys.get_stream_access_level(stream_1, tst_fabric_name) == 'ro'
+    apiKeys.set_stream_access_level(stream_2, tst_fabric_name, 'rw')
+    assert apiKeys.get_stream_access_level(stream_2, tst_fabric_name) == 'rw'
+    stream = tst_fabric.stream()
+    time.sleep(2)
+    with assert_raises(websocket._exceptions.WebSocketBadStatusException) as err:
+        stream.create_producer(stream_name_1)
+    assert "401 Unauthorized" in str(err.value)
+    stream.subscribe(stream_name_1)
+  
+    stream.create_producer(stream_name_2)
+    stream.subscribe(stream_name_2)
+    resp = apiKeys.list_accessible_streams(tst_fabric_name)
+    assert resp[stream_1] == 'ro'
+    assert resp[stream_2] == 'rw'
+
+    # Test reset permission (stream level) and delete stream
+    assert apiKeys.clear_stream_access_level(stream_1, tst_fabric_name) is True
+    assert apiKeys.get_stream_access_level(stream_1, tst_fabric_name) == 'rw'
+    time.sleep(2)
+    stream.create_producer(stream_name_1)
+    stream.create_producer(stream_name_2)
+    assert tst_fabric.delete_stream(stream_1) is True
+    assert tst_fabric.delete_stream(stream_2) is True
+
+    client._fabric.delete_fabric(tst_fabric_name)
+
+    # Basic tests for billing access level management
+    resp = apiKeys.set_billing_access_level('rw')
+    assert resp['error'] == False
+    resp = apiKeys.get_billing_access_level()
+    assert resp['billing'] == 'rw'
+    resp = apiKeys.clear_billing_access_level()
+    assert resp['error'] == False
+    resp = apiKeys.get_billing_access_level()
+    assert resp['billing'] == 'none'
+
+    assert client.remove_api_key(apikey_id) is True
+
+def test_attributes(client):
+    # Create apikey
+    apikey_id = generate_apikey_id()
+    resp = client.create_api_key(apikey_id)
+    assert resp['error'] == False
+    apikey = resp['key']
+
+    assert apikey_id in extract('keyid', client.list_all_api_keys())
+
+    resp = client.get_api_key(apikey_id)
+    assert resp['error'] == False
+
+    user = client.tenant(apikey=apikey)
+    sys_fabric = user.useFabric("_system")
+    apiKeys = sys_fabric.api_keys(apikey_id)
+
+    # Tests for user attributes management
+    resp = apiKeys.update_attributes('{"foo": "bar", "boo": "baz", "soo": "kon"}')
+    assert resp['error'] == False
+    resp = apiKeys.get_attributes()
+    assert resp['result'] == {"foo": "bar", "boo": "baz", "soo": "kon"}
+
+    resp = apiKeys.update_attributes('{"foo": "baz", "boo": "bar"}')
+    assert resp['error'] == False
+    resp = apiKeys.get_attributes()
+    assert resp['result'] == {"foo": "baz", "boo": "bar", "soo": "kon"}
+
+    resp = apiKeys.remove_attribute("soo")
+    assert resp['error'] == False
+    resp = apiKeys.get_attributes()
+    assert resp['result'] == {"foo": "baz", "boo": "bar"}
+
+    resp = apiKeys.remove_all_attributes()
+    assert resp['error'] == False
+    resp = apiKeys.get_attributes()
+    assert resp['result'] == {}
+
+    assert client.remove_api_key(apikey_id) is True
+
+def test_permission_exceptions(client):
+    apikey_id = generate_apikey_id()
+    col_name_1 = generate_col_name()
+    sys_fabric = client._tenant.useFabric("_system")
+    
+    assert client.create_collection(col_name_1) is not None
+
+    # Test invalid apikey
+    bad_apikey_id = "apikey-test%"
+    with assert_raises(CreateAPIKey) as err:
+        client.create_api_key(bad_apikey_id)
+    assert err.value.http_code == 400
+
+    with assert_raises(GetAPIKeys) as err:
+        client.get_api_key(bad_apikey_id)
+    assert err.value.http_code == 400
+
+    with assert_raises(RemoveAPIKey) as err:
+        client.remove_api_key(bad_apikey_id)
+    assert err.value.http_code == 400
+
+    # Test that with invalid apikey, permissions (fabric level) should not be accessible
+    with assert_raises(ListDataBases) as err:
+        client.list_accessible_databases(apikey_id)
+    assert err.value.http_code == 404
+
+    with assert_raises(DataBaseAccessLevel) as err:
+        client.get_database_access_level(apikey_id, sys_fabric.name)
+    assert err.value.http_code == 404
+
+    with assert_raises(ClearDataBaseAccessLevel) as err:
+        client.clear_database_access_level(apikey_id, sys_fabric.name)
+    assert err.value.http_code == 404
+
+    with assert_raises(SetDataBaseAccessLevel) as err:
+        client.set_database_access_level(apikey_id, sys_fabric.name, 'rw')
+    assert err.value.http_code == 404
+
+    # Test that with invalid apikey, permissions (collection level) should not be accessible
+    with assert_raises(CollectionAccessLevel) as err:
+        client.list_accessible_collections(apikey_id)
+    assert err.value.http_code == 404
+
+    with assert_raises(CollectionAccessLevel) as err:
+        client.get_collection_access_level(apikey_id, col_name_1)
+    assert err.value.http_code == 404
+
+    with assert_raises(SetCollectionAccessLevel) as err:
+        client.set_collection_access_level(apikey_id, col_name_1, sys_fabric.name, 'rw')
+    assert err.value.http_code == 404
+
+    with assert_raises(ClearCollectionAccessLevel) as err:
+        client.clear_collection_access_level(apikey_id, col_name_1)
+    assert err.value.http_code == 404
+
+    # Test that with invalid apikey, permissions (stream level) should not be accessible
+    with assert_raises(ListStreams) as err:
+        client.list_accessible_streams(apikey_id)
+    assert err.value.http_code == 404
+
+    stream_name_1 = generate_stream_name()
+    sys_fabric.create_stream(stream_name_1)
+
+    stream_1 = f'c8globals.{stream_name_1}'
+
+    with assert_raises(StreamAccessLevel) as err:
+        client.get_stream_access_level(apikey_id, stream_1)
+    assert err.value.http_code == 404
+
+    with assert_raises(SetStreamAccessLevel) as err:
+        client.set_stream_access_level(apikey_id, stream_1, sys_fabric.name, 'rw')
+    assert err.value.http_code == 404
+
+    with assert_raises(ClearStreamAccessLevel) as err:
+        client.clear_stream_access_level(apikey_id, stream_1)
+    assert err.value.http_code == 404
+
+    # Test that with invalid apikey, permissions (billing level) should not be accessible
+    with assert_raises(BillingAccessLevel) as err:
+        client.get_billing_access_level(apikey_id)
+    assert err.value.http_code == 404
+
+    with assert_raises(SetBillingAccessLevel) as err:
+        client.set_billing_access_level(apikey_id, 'rw')
+    assert err.value.http_code == 404
+
+    with assert_raises(ClearBillingAccessLevel) as err:
+        client.clear_billing_access_level(apikey_id)
+    assert err.value.http_code == 404
+
+    # Test that with invalid apikey, attributes should not be accessible
+    with assert_raises(GetAttributes) as err:
+        client.get_attributes(apikey_id)
+    assert err.value.http_code == 404
+
+    with assert_raises(UpdateAttributes) as err:
+        client.update_attributes(apikey_id, '{"foo": "bar"}')
+    assert err.value.http_code == 404
+
+    with assert_raises(RemoveAllAttributes) as err:
+        client.remove_all_attributes(apikey_id)
+    assert err.value.http_code == 404
+
+    with assert_raises(RemoveAttribute) as err:
+        client.remove_attribute(apikey_id, "foo")
+    assert err.value.http_code == 404
+
+    assert sys_fabric.delete_stream(stream_1) is True
+    assert sys_fabric.delete_collection(col_name_1) is True

--- a/tests/test_permission.py
+++ b/tests/test_permission.py
@@ -1,140 +1,350 @@
 from __future__ import absolute_import, unicode_literals
-
+import time
+import websocket
 from c8.exceptions import (
     CollectionCreateError,
     CollectionListError,
-    CollectionPropertiesError,
+    DataBaseError,
+    GetDataBaseAccessLevel,
+    SetDataBaseAccessLevel,
+    ClearDataBaseAccessLevel,
+    SetCollectionAccessLevel,
+    CollectionAccessLevel,
+    ClearCollectionAccessLevel,
     DocumentInsertError,
-    PermissionResetError,
-    PermissionGetError,
-    PermissionUpdateError,
-    PermissionListError
+    DocumentGetError,
+    ListStreams,
+    StreamAccessLevel,
+    SetStreamAccessLevel,
+    ClearStreamAccessLevel,
+    SetBillingAccessLevel,
+    BillingAccessLevel,
+    ClearBillingAccessLevel,
+    GetAttributes,
+    UpdateAttributes,
+    RemoveAllAttributes,
+    RemoveAttribute
 )
 from tests.helpers import (
     assert_raises,
     extract,
     generate_col_name,
-    generate_db_name,
+    generate_stream_name,
+    generate_fabric_name,
     generate_string,
     generate_username
 )
 
-
-def test_permission_management(client, sys_db, bad_db):
-    username = generate_username()
+def test_permission_management(client, sys_fabric):
+    # Create user
+    display_name = generate_username()
+    email = f"{display_name}@macrometa.com"
     password = generate_string()
-    db_name = generate_db_name()
+    new_user = client.create_user(
+        email = email,
+        display_name=display_name,
+        password=password,
+        active=True,
+        extra={'foo': 'bar'},
+    )
+
+    username = new_user['username']
+    assert client.has_user(username)
+
+    sys_fabric = client._tenant.useFabric("_system")
+    tst_fabric_name = generate_fabric_name()
     col_name_1 = generate_col_name()
     col_name_2 = generate_col_name()
+    col_name_3 = generate_col_name()
 
-    sys_db.create_fabric(
-        name=db_name,
-        users=[{
-            'username': username,
-            'password': password,
-            'active': True
-        }]
+    sys_fabric.create_fabric(
+        name=tst_fabric_name,
+        users=['root']
     )
-    db = client.db(db_name, username, password)
-    assert isinstance(sys_db.permissions(username), dict)
 
-    # Test list permissions with bad fabric
-    with assert_raises(PermissionListError) as err:
-        bad_db.permissions(username)
-    assert err.value.error_code == 1228
-
-    # Test get permission with bad fabric
-    with assert_raises(PermissionGetError) as err:
-        bad_db.permission(username, db_name)
-    assert err.value.error_code == 1228
-
-    # The user should have read and write permissions
-    assert sys_db.permission(username, db_name) == 'rw'
-    assert sys_db.permission(username, db_name, col_name_1) == 'rw'
-    assert db.create_collection(col_name_1) is not None
-    assert col_name_1 in extract('name', db.collections())
+    assert isinstance(client.get_permissions(username), dict)
 
     # Test update permission (fabric level) to none and verify access
-    assert sys_db.update_permission(username, 'none', db_name) is True
-    assert sys_db.permission(username, db_name) == 'none'
+    resp = client.set_database_access_level_user(username, tst_fabric_name, 'none')
+    assert resp['error'] == False
+    assert client.get_database_access_level_user(username, tst_fabric_name) == 'none'
+    user_1 = client.tenant(email, password)
+    assert resp['error'] == False
+    tst_fabric = user_1.useFabric(tst_fabric_name)
     with assert_raises(CollectionCreateError) as err:
-        db.create_collection(col_name_2)
+        tst_fabric.create_collection(col_name_2)
     assert err.value.http_code == 401
     with assert_raises(CollectionListError) as err:
-        db.collections()
+        tst_fabric.collections()
     assert err.value.http_code == 401
 
-    # Test update permission (fabric level) with bad fabric
-    with assert_raises(PermissionUpdateError):
-        bad_db.update_permission(username, 'ro', db_name)
-    assert sys_db.permission(username, db_name) == 'none'
+    assert sys_fabric.create_collection(col_name_1) is not None
+    assert col_name_1 in extract('name', sys_fabric.collections())
+    resp = client.list_accessible_databases_user(username)
+    assert resp['_system'] == 'ro'
 
     # Test update permission (fabric level) to read only and verify access
-    assert sys_db.update_permission(username, 'ro', db_name) is True
-    assert sys_db.permission(username, db_name) == 'ro'
+    resp = client.set_database_access_level_user(username, tst_fabric_name, 'ro')
+    assert resp['error'] == False
+    assert client.get_database_access_level_user(username, tst_fabric_name) == 'ro'
     with assert_raises(CollectionCreateError) as err:
-        db.create_collection(col_name_2)
+        tst_fabric.create_collection(col_name_2)
     assert err.value.http_code == 403
-    assert col_name_1 in extract('name', db.collections())
-    assert col_name_2 not in extract('name', db.collections())
-
-    # Test reset permission (fabric level) with bad fabric
-    with assert_raises(PermissionResetError) as err:
-        bad_db.reset_permission(username, db_name)
-    assert err.value.error_code == 1228
-    assert sys_db.permission(username, db_name) == 'ro'
+    assert col_name_1 in extract('name', sys_fabric.collections())
+    assert col_name_2 not in extract('name', tst_fabric.collections())
 
     # Test reset permission (fabric level) and verify access
-    assert sys_db.reset_permission(username, db_name) is True
-    assert sys_db.permission(username, db_name) == 'none'
+    assert client.remove_database_access_level_user(username, tst_fabric_name) is True
+    assert client.get_database_access_level_user(username, tst_fabric_name) == 'none'
     with assert_raises(CollectionCreateError) as err:
-        db.create_collection(col_name_1)
+        tst_fabric.create_collection(col_name_1)
     assert err.value.http_code == 401
     with assert_raises(CollectionListError) as err:
-        db.collections()
+        tst_fabric.collections()
     assert err.value.http_code == 401
 
     # Test update permission (fabric level) and verify access
-    assert sys_db.update_permission(username, 'rw', db_name) is True
-    assert sys_db.permission(username, db_name, col_name_2) == 'rw'
-    assert db.create_collection(col_name_2) is not None
-    assert col_name_2 in extract('name', db.collections())
+    client.set_database_access_level_user(username, tst_fabric_name, 'rw')
+    assert client.get_database_access_level_user(username, tst_fabric_name) == 'rw'
+    assert tst_fabric.create_collection(col_name_2) is not None
+    assert col_name_2 in extract('name', tst_fabric.collections())
+    assert tst_fabric.create_collection(col_name_3) is not None
+    assert col_name_3 in extract('name', tst_fabric.collections())
 
-    col_1 = db.collection(col_name_1)
-    col_2 = db.collection(col_name_2)
+    col_2 = tst_fabric.collection(col_name_2)
+    col_3 = tst_fabric.collection(col_name_3)
 
-    # Verify that user has read and write access to both collections
-    assert isinstance(col_1.properties(), dict)
-    assert isinstance(col_1.insert({}), dict)
-    assert isinstance(col_2.properties(), dict)
+    resp = client.list_accessible_collections_user(username, tst_fabric_name)
+    assert resp[col_name_2] == 'rw'
+    assert resp[col_name_3] == 'rw'
+
+    # Verify that user has read and write access to the collection
     assert isinstance(col_2.insert({}), dict)
+    assert isinstance(col_3.insert({}), dict)
 
     # Test update permission (collection level) to read only and verify access
-    assert sys_db.update_permission(username, 'ro', db_name, col_name_1)
-    assert sys_db.permission(username, db_name, col_name_1) == 'ro'
-    assert isinstance(col_1.properties(), dict)
+    client.set_collection_access_level_user(username, col_name_2, tst_fabric_name, 'ro')
+    assert client.get_collection_access_level_user(username, col_name_2, tst_fabric_name) == 'ro'
+    assert isinstance(col_2.export(), list)
     with assert_raises(DocumentInsertError) as err:
-        col_1.insert({})
+        col_2.insert({})
     assert err.value.http_code == 403
-    assert isinstance(col_2.properties(), dict)
-    assert isinstance(col_2.insert({}), dict)
+    assert isinstance(col_3.insert({}), dict)
 
     # Test update permission (collection level) to none and verify access
-    assert sys_db.update_permission(username, 'none', db_name, col_name_1)
-    assert sys_db.permission(username, db_name, col_name_1) == 'none'
-    with assert_raises(CollectionPropertiesError) as err:
-        col_1.properties()
+    client.set_collection_access_level_user(username, col_name_2, tst_fabric_name, 'none')
+    assert client.get_collection_access_level_user(username, col_name_2, tst_fabric_name) == 'none'
+    with assert_raises(DocumentGetError) as err:
+        col_2.export()
     assert err.value.http_code == 403
     with assert_raises(DocumentInsertError) as err:
-        col_1.insert({})
+        col_2.insert({})
     assert err.value.http_code == 403
-    assert isinstance(col_2.properties(), dict)
-    assert isinstance(col_2.insert({}), dict)
+    assert isinstance(col_3.export(), list)
+    assert isinstance(col_3.insert({}), dict)
 
     # Test reset permission (collection level)
-    assert sys_db.reset_permission(username, db_name, col_name_1) is True
-    assert sys_db.permission(username, db_name, col_name_1) == 'rw'
-    assert isinstance(col_1.properties(), dict)
-    assert isinstance(col_1.insert({}), dict)
-    assert isinstance(col_2.properties(), dict)
+    assert client.clear_collection_access_level_user(username, col_name_2, tst_fabric_name) is True
+    assert client.get_collection_access_level_user(username, col_name_2, tst_fabric_name) == 'rw'
     assert isinstance(col_2.insert({}), dict)
+    assert isinstance(col_3.insert({}), dict)
+
+    # Test permissions (stream level)
+    stream_name_1 = generate_stream_name()
+    stream_name_2 = generate_stream_name()
+    tst_fabric.create_stream(stream_name_1)
+    tst_fabric.create_stream(stream_name_2)
+
+    stream_1 = f'c8globals.{stream_name_1}'
+    stream_2 = f'c8globals.{stream_name_2}'
+
+    # Test update permission (stream level) to read only and read write and verify access
+    client.set_stream_access_level_user(username, stream_1, tst_fabric_name, 'ro')
+    assert client.get_stream_access_level_user(username, stream_1, tst_fabric_name) == 'ro'
+    client.set_stream_access_level_user(username, stream_2, tst_fabric_name, 'rw')
+    assert client.get_stream_access_level_user(username, stream_2, tst_fabric_name) == 'rw'
+    stream = tst_fabric.stream()
+    time.sleep(2)
+    with assert_raises(websocket._exceptions.WebSocketBadStatusException) as err:
+        stream.create_producer(stream_name_1)
+    assert "401 Unauthorized" in str(err.value)
+    stream.subscribe(stream_name_1)
+  
+    stream.create_producer(stream_name_2)
+    stream.subscribe(stream_name_2)
+    resp = client.list_accessible_streams_user(username, tst_fabric_name)
+    assert resp[stream_1] == 'ro'
+    assert resp[stream_2] == 'rw'
+
+    # Test reset permission (stream level) and delete stream
+    assert client.clear_stream_access_level_user(username, stream_1, tst_fabric_name) is True
+    assert client.get_stream_access_level_user(username, stream_1, tst_fabric_name) == 'rw'
+    time.sleep(2)
+    stream.create_producer(stream_name_1)
+    stream.create_producer(stream_name_2)
+    assert tst_fabric.delete_stream(stream_1) is True
+    assert tst_fabric.delete_stream(stream_2) is True
+
+    sys_fabric = client._tenant.useFabric("_system")
+    sys_fabric.delete_fabric(tst_fabric_name)
+    sys_fabric.delete_collection(col_name_1)
+
+    # Basic tests for billing access level management
+    resp = client.set_billing_access_level_user(username, 'rw')
+    assert resp['error'] == False
+    resp = client.get_billing_access_level_user(username)
+    assert resp['billing'] == 'rw'
+    resp = client.clear_billing_access_level_user(username)
+    assert resp['error'] == False
+    resp = client.get_billing_access_level_user(username)
+    assert resp['billing'] == 'none'
+    assert client.delete_user(username) is True
+
+def test_attributes_user(client):
+    # Create user
+    display_name = generate_username()
+    email = f"{display_name}@macrometa.com"
+    password = generate_string()
+    new_user = client.create_user(
+        email = email,
+        display_name=display_name,
+        password=password,
+        active=True,
+        extra={'foo': 'bar'},
+    )
+
+    username = new_user['username']
+    assert client.has_user(username)
+
+    # Tests for user attributes management
+    resp = client.update_attributes_user(username, '{"foo": "bar", "boo": "baz", "soo": "kon"}')
+    assert resp['error'] == False
+    resp = client.get_attributes_user(username)
+    assert resp['result'] == {"foo": "bar", "boo": "baz", "soo": "kon"}
+
+    resp = client.update_attributes_user(username, '{"foo": "baz", "boo": "bar"}')
+    assert resp['error'] == False
+    resp = client.get_attributes_user(username)
+    assert resp['result'] == {"foo": "baz", "boo": "bar", "soo": "kon"}
+
+    resp = client.remove_attribute_user(username, "soo")
+    assert resp['error'] == False
+    resp = client.get_attributes_user(username)
+    assert resp['result'] == {"foo": "baz", "boo": "bar"}
+
+    resp = client.remove_all_attributes_user(username)
+    assert resp['error'] == False
+    resp = client.get_attributes_user(username)
+    assert resp['result'] == {}
+
+    assert client.delete_user(username) is True
+
+def test_permission_exceptions(client, sys_fabric):
+    # Create user
+    username = generate_username()
+    display_name = generate_username()
+    email = f"{display_name}@macrometa.com"
+    password = generate_string()
+    new_user = client.create_user(
+        email = email,
+        display_name=display_name,
+        password=password,
+        active=True,
+        extra={'foo': 'bar'},
+    )
+
+    username_2 = new_user['username']
+    assert client.has_user(username_2)
+    user = client.tenant(email, password)
+
+    col_name_1 = generate_col_name()
+    assert sys_fabric.create_collection(col_name_1) is not None
+
+    # Test that missing users should not be able to access permissions (fabric level)
+    with assert_raises(DataBaseError) as err:
+        client.list_accessible_databases_user(username)
+    assert err.value.http_code == 404
+
+    with assert_raises(GetDataBaseAccessLevel) as err:
+        client.get_database_access_level_user(username, sys_fabric.name)
+    assert err.value.http_code == 404
+
+    with assert_raises(ClearDataBaseAccessLevel) as err:
+        client.remove_database_access_level_user(username, sys_fabric.name)
+    assert err.value.http_code == 404
+
+    with assert_raises(SetDataBaseAccessLevel) as err:
+        client.set_database_access_level_user(username, sys_fabric.name, 'rw')
+    assert err.value.http_code == 404
+
+    # Test that missing users should not be able to access permissions (collection level)
+    with assert_raises(CollectionAccessLevel) as err:
+        client.list_accessible_collections_user(username)
+    assert err.value.http_code == 404
+
+    with assert_raises(CollectionAccessLevel) as err:
+        client.get_collection_access_level_user(username, col_name_1)
+    assert err.value.http_code == 404
+
+    with assert_raises(SetCollectionAccessLevel) as err:
+        client.set_collection_access_level_user(username, col_name_1, sys_fabric.name, 'rw')
+    assert err.value.http_code == 404
+
+    with assert_raises(ClearCollectionAccessLevel) as err:
+        client.clear_collection_access_level_user(username, col_name_1)
+    assert err.value.http_code == 404
+
+    # Test that missing users should not be able to access permissions (stream level)
+    with assert_raises(ListStreams) as err:
+        client.list_accessible_streams_user(username)
+    assert err.value.http_code == 404
+
+    stream_name_1 = generate_stream_name()
+    sys_fabric.create_stream(stream_name_1)
+
+    stream_1 = f'c8globals.{stream_name_1}'
+
+    with assert_raises(StreamAccessLevel) as err:
+        client.get_stream_access_level_user(username, stream_1)
+    assert err.value.http_code == 404
+
+    with assert_raises(SetStreamAccessLevel) as err:
+        client.set_stream_access_level_user(username, stream_1, sys_fabric.name, 'rw')
+    assert err.value.http_code == 404
+
+    with assert_raises(ClearStreamAccessLevel) as err:
+        client.clear_stream_access_level_user(username, stream_1)
+    assert err.value.http_code == 404
+
+    # Test that missing users should not be able to access permissions (billing level)
+    with assert_raises(BillingAccessLevel) as err:
+        client.get_billing_access_level_user(username)
+    assert err.value.http_code == 404
+
+    with assert_raises(SetBillingAccessLevel) as err:
+        client.set_billing_access_level_user(username, 'rw')
+    assert err.value.http_code == 404
+
+    with assert_raises(ClearBillingAccessLevel) as err:
+        client.clear_billing_access_level_user(username)
+    assert err.value.http_code == 404
+
+    # Test that only root users can access attributes
+    with assert_raises(GetAttributes) as err:
+        user.get_attributes_user(username)
+    assert err.value.http_code == 403
+
+    with assert_raises(UpdateAttributes) as err:
+        user.update_attributes_user(username, '{"foo": "bar"}')
+    assert err.value.http_code == 403
+
+    with assert_raises(RemoveAllAttributes) as err:
+        user.remove_all_attributes_user(username)
+    assert err.value.http_code == 403
+
+    with assert_raises(RemoveAttribute) as err:
+        user.remove_attribute_user(username, "foo")
+    assert err.value.http_code == 403
+
+    assert sys_fabric.delete_stream(stream_1) is True
+    assert sys_fabric.delete_collection(col_name_1) is True


### PR DESCRIPTION
## Description

Added test_apikeys.py to cover tests for all the existing api methods for apikeys, also added some new methods which were missing in pyC8, corrected the url prefix to "/_api" for apikey related api.

Updated test_permission.py to cover tests for all the existing api methods for access levels(fabric, collection, streams, billing) and attributes, also added some new methods which were missing in pyC8

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


**Test Configuration**:

* C8 Version:

## Reviews

Please identify two developers to review this change

- [ ] @ricardo-macrometa 
- [x] @dlozina-macrometa 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added new functional tests that prove my fix is effective or that my feature works
- [x] Existing and new functional tests pass with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
