### PR TITLE
PYDR-72 Add Billing APIs and fixing failing flaky tests reducing test execution time

### DIFF
--- a/c8/billing/billing_interface.py
+++ b/c8/billing/billing_interface.py
@@ -1,0 +1,204 @@
+from c8.executor import DefaultExecutor
+from c8.api import APIWrapper
+
+from c8.billing.core import build_request, BillingServerError
+
+
+class BillingInterface(APIWrapper):
+
+    """Billing API wrapper.
+
+    :param connection: HTTP connection.
+    :type connection: c8.connection.Connection
+    :param executor: API executor.
+    :type executor: c8.executor.Executor
+    """
+
+    def __init__(self, connection):
+        super(BillingInterface, self).__init__(connection, executor=DefaultExecutor(connection))
+
+    def __repr__(self):
+        return '<BillingInterface> for {}'()
+
+    def execute(self, request):
+        def response_handler(response):
+            if not response.is_success and request is not None:
+                raise BillingServerError(response, request)
+            return response.body
+
+        return self._execute(request, response_handler, custom_prefix="/_api/billing")
+
+    def get_account(self, tenant=None):
+        """
+        Get account details (plan, contact and payment settings) for given tenant.
+        Note: If tenant name is not specified, the tenant invoking the API is used.
+              This API is not applicable for system tenants.
+
+        :param tenant: Tenant name/id (not the display name)
+        :type tenant: str
+        :returns: Account details of the given tenant.
+        :rtype: dict
+        :raise c8.billing.core.BillingServerError If list fails.
+        """
+        request = build_request(method='GET', endpoint='/account', tenant=tenant)
+        return self.execute(request)
+
+    def update_contact(self, tenant=None, contact={}):
+        """
+        Update contact details for given tenant.
+        Note: If tenant name is not specified, the tenant invoking the API is used.
+              This API is not applicable for system tenants.
+
+        :param tenant: Tenant name/id (not the display name)
+        :type tenant: str
+        :param contact: Contact object
+        :type tenant: dict
+        :returns: Updated contact details of the given tenant.
+        :rtype: dict
+        :raise c8.billing.core.BillingServerError If list fails.
+        """
+        data = {}
+        attributes = [
+            'firstname',
+            'lastname',
+            'email',
+            'phone',
+            'line1',
+            'line2',
+            'city',
+            'state',
+            'country',
+            'zipcode'
+        ]
+
+        for attribute in attributes:
+            if attribute in contact:
+                data[attribute] = contact[attribute]
+
+        request = build_request(method='PUT', endpoint='/contact', tenant=tenant, data=data)
+        return self.execute(request)
+
+    def get_previous_payments(self, tenant=None, months=10):
+        """
+        Fetch all payments details of the tenant for specified number of previous months.
+        Note: If tenant name is not specified, the tenant invoking the API is used.
+              This API is not applicable for system tenants.
+
+        :param tenant: Tenant name/id (not the display name)
+        :type tenant: str
+        :param limit: Number of previous months for which payment details are required.
+        :type limit: int
+        :returns: Payment details of the given tenant for the specified number of previous months.
+        :rtype: dict
+        :raise c8.billing.core.BillingServerError If list fails.
+        """
+        params = {"limit": months}
+        request = build_request(method='GET', endpoint='/payments', tenant=tenant, params=params)
+        return self.execute(request)
+
+    def get_previous_invoices(self, tenant=None, months=3):
+        """
+        Fetch all invoice details of the tenant for specified number of previous months.
+        Note: If tenant name is not specified, the tenant invoking the API is used.
+              This API is not applicable for system tenants.
+
+        :param tenant: Tenant name/id (not the display name)
+        :type tenant: str
+        :param limit: Number of previous months for which invoices details are required.
+        :type limit: int
+        :returns: Invoice details of the given tenant for the specified number of previous months.
+        :rtype: dict
+        :raise c8.billing.core.BillingServerError If list fails.
+        """
+        params = {"limit": months}
+        request = build_request(method='GET', endpoint='/invoices', tenant=tenant, params=params)
+        return self.execute(request)
+
+    def get_current_invoice(self, tenant=None):
+        """
+        Fetch invoice of the tenant for the current month.
+        Note: If tenant name is not specified, the tenant invoking the API is used.
+              This API is not applicable for system tenants.
+
+        :param tenant: Tenant name/id (not the display name)
+        :type tenant: str
+        :returns: Invoice details of the given tenant for the current month.
+        :rtype: dict
+        :raise c8.billing.core.BillingServerError If list fails.
+        """
+        request = build_request(method='GET', endpoint='/invoice/current', tenant=tenant)
+        return self.execute(request)
+
+    def get_specific_invoice(self, year, month, tenant=None):
+        """
+        Fetch invoice for a tenant, in a specific month and year.
+        Note: If tenant name is not specified, the tenant invoking the API is used.
+              This API is not applicable for system tenants.
+
+        :param year: Year for which the invoice detail is required (in YYYY format).
+        :type year: int
+        :param month: Month for which the invoice detail is required. Valid values [1..12].
+        :type month: int
+        :param tenant: Tenant name/id (not the display name)
+        :type tenant: str
+        :returns: Invoice detail of the given tenant for the specified year and month.
+        :rtype: dict
+        :raise c8.billing.core.BillingServerError If list fails.
+        """
+        request = build_request(method='GET', 
+                                endpoint='/invoices/{}/{}'.format(year, month), 
+                                tenant=tenant)
+        return self.execute(request)
+
+    def get_usage(self, tenant=None, start_date=None, end_date=None):
+        """
+        Fetch usage of a tenant in a specific date range. If no query parameters are specified, usage from 
+        start date of the month to current date is returned.
+        Note: If tenant name is not specified, the tenant invoking the API is used.
+              This API is not applicable for system tenants.
+
+        :param tenant: Tenant name/id (not the display name)
+        :type tenant: str
+        :param start_date: Start date in 'YYYY-MM-DD' format.
+        :type start_date: str
+        :param end_date: End date in 'YYYY-MM-DD' format.
+        :type end_date: str
+        :returns: Usage details of the given tenant for the specified date range.
+        :rtype: dict
+        :raise c8.billing.core.BillingServerError If list fails.
+        """
+        params={}
+        if start_date is not None and end_date is not None:
+            params = {"startDate": start_date, "endDate": end_date}
+
+        request = build_request(method='GET', endpoint='/usage', tenant=tenant, params=params)
+        return self.execute(request)
+
+    def get_usage_region(self, region, tenant=None, start_date=None, end_date=None):
+        """
+        Fetch usage of a tenant in a specific date range for a specific region. If no query parameters are specified,
+        usage from start date of the month to current date is returned.
+        Note: If tenant name is not specified, the tenant invoking the API is used.
+              This API is not applicable for system tenants.
+
+        :param region: Name of the region.
+        :type region: str
+        :param tenant: Tenant name/id (not the display name)
+        :type tenant: str
+        :param start_date: Start date in 'YYYY-MM-DD' format.
+        :type start_date: str
+        :param end_date: End date in 'YYYY-MM-DD' format.
+        :type end_date: str
+        :returns: Usage details of the given tenant for the specified date range.
+        :rtype: dict
+        :raise c8.billing.core.BillingServerError If list fails.
+        """
+        params={}
+        if start_date is not None and end_date is not None:
+            params = {"startDate": start_date, "endDate": end_date}
+
+        request = build_request(method='GET',
+                                endpoint='/region/{}/usage'.format(region),
+                                tenant=tenant,
+                                params=params)
+        return self.execute(request)

--- a/c8/billing/core.py
+++ b/c8/billing/core.py
@@ -1,0 +1,19 @@
+from c8.request import Request
+from c8.exceptions import C8ServerError
+
+
+def build_request(method, endpoint, tenant, data=None, params=None):
+    headers = {"tenant": tenant}
+    request = Request(
+        method=method,
+        endpoint=endpoint,
+        headers=headers,
+        data=data,
+        params=params
+    )
+    return request
+
+
+class BillingServerError(C8ServerError):
+    """Billing Server Error"""
+

--- a/c8/client.py
+++ b/c8/client.py
@@ -51,6 +51,7 @@ class C8Client(object):
         self.get_tenant()
         # Domains
         self._redis = None
+        self._billing = None
 
     def set_url(self):
         if "api-" in self.host:
@@ -92,6 +93,18 @@ class C8Client(object):
         if self._redis is None:
             self._redis = RedisCommands(self._tenant._conn)
         return self._redis
+
+    @property
+    def billing(self):
+        """
+        Access Macrometa Billing Interface
+
+        :returns: Macrometa Billing interface
+        :rtype: c8.billing.billing_interface
+        """
+        if self._billing is None:
+            self._billing = BillingInterface(self._tenant._conn)
+        return self._billing
 
     @property
     def version(self):

--- a/c8/client.py
+++ b/c8/client.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from c8.connection import TenantConnection
 from c8.plan.plan_interface import PlanInterface
+from c8.billing.billing_interface import BillingInterface
 from c8.tenant import Tenant
 from c8.redis.redis_commands import RedisCommands
 from c8.version import __version__

--- a/c8/connection.py
+++ b/c8/connection.py
@@ -44,11 +44,6 @@ class Connection(object):
         self._apikey = apikey
         self._header = ''
 
-        # Construct the URL prefix in the required format.
-        #if not fabric_name:
-        #    self._fabric_name = constants.DB_DEFAULT
-        #else:
-        #    self._fabric_name = fabric_name
         if self._token != None:
             self._auth_token = self._token
 
@@ -63,7 +58,7 @@ class Connection(object):
             headers = {"Authorization": "Bearer " + self._auth_token}
             self._header = headers
 
-            tenurl = self.url + "/_fabric/{}/_api/user".format(self._fabric_name)
+            tenurl = self.url + "/_api/user"
             response = requests.get(url=tenurl, headers=headers)
             if response.status_code == 200:
                 body = json.loads(response.text)
@@ -73,16 +68,12 @@ class Connection(object):
         if self._tenant_name == '' and self._apikey is not None :
             headers = {"Authorization": "apikey " + self._auth_token}
             self._header = headers
-            tenurl = self.url + "/_fabric/{}/_api/user".format(self._fabric_name)
+            tenurl = self.url + "/_api/user"
             response = requests.get(url=tenurl, headers=headers)
             if response.status_code == 200:
                 body = json.loads(response.text)
                 self._tenant_name = body['result'][0]['tenant']
 
-
-
-        #self._url_prefix = '{}/_tenant/{}/_fabric/{}'.format(
-        #    url, self._tenant_name, self._fabric_name)
 
         self._url_prefix = '{}/_fabric/{}/_api'.format(
           url, self._fabric_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals, division
 
 import pytest
-import time
 import os
 
 from dotenv import load_dotenv
@@ -60,7 +59,6 @@ def pytest_configure(config):
 
     # Create a standard collection for testing.
     col_name = generate_col_name()
-    time.sleep(5)
     tst_col = tst_fabric.create_collection(col_name, edge=False)
     tst_col.add_skiplist_index(['val'])
     tst_col.add_fulltext_index(['text'])

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -94,7 +94,7 @@ def test_data_document():
 
 def test_data_billing_plan():
     return {
-        "name": "Test",
+        "name": "TestPyC8",
         "planId": "1",
         "description": "New billing plan.",
         "featureGates": [
@@ -150,7 +150,7 @@ def test_data_update_plan():
 def test_update_tenant_billing_plan():
     return {
         "attribution": "Macrometa",
-        "plan": "Test",
+        "plan": "TestPyC8",
         "tenant": "edgar.garcia_macrometa.com",
         "payment_method_id": "pm_1KRHKj2eZvKYlo2CHkt3ra77"
     }

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,33 +1,36 @@
 import os
+import pytest
 
 from dotenv import load_dotenv
 
 from c8 import C8Client
 
 
+load_dotenv()
+client = C8Client(protocol='https',
+                  host=os.environ.get('FEDERATION_URL'),
+                  port=443,
+                  email=os.environ.get('TENANT_EMAIL'),
+                  apikey=os.environ.get('API_KEY'),
+                  geofabric=os.environ.get('FABRIC')
+                  )
+
+mm_client = C8Client(protocol='https',
+                  host=os.environ.get('FEDERATION_URL'),
+                  port=443,
+                  email=os.environ.get('MM_TENANT_EMAIL'),
+                  apikey=os.environ.get('MM_API_KEY'),
+                  geofabric=os.environ.get('FABRIC')
+                  )
+
+
+@pytest.fixture
 def get_client_instance():
-    load_dotenv()
-    client = C8Client(protocol='https',
-                      host=os.environ.get('FEDERATION_URL'),
-                      port=443,
-                      email=os.environ.get('TENANT_EMAIL'),
-                      apikey=os.environ.get('API_KEY'),
-                      geofabric=os.environ.get('FABRIC')
-                      )
     return client
 
-
+@pytest.fixture
 def get_mm_client_instance():
-    load_dotenv()
-    client = C8Client(protocol='https',
-                      host=os.environ.get('FEDERATION_URL'),
-                      port=443,
-                      email=os.environ.get('MM_TENANT_EMAIL'),
-                      apikey=os.environ.get('MM_API_KEY'),
-                      geofabric=os.environ.get('FABRIC')
-                      )
-    return client
-
+    return mm_client
 
 def test_data_document():
     return [

--- a/tests/e2e/test_billing.py
+++ b/tests/e2e/test_billing.py
@@ -1,0 +1,89 @@
+import pytest
+from datetime import date, timedelta
+from tests.helpers import assert_raises
+from c8.billing.core import BillingServerError
+
+@pytest.fixture
+def get_dates():
+    end_date = date.today().strftime("%Y-%m-%d")
+    start_date = (date.today() - timedelta(days=30)).strftime("%Y-%m-%d")
+    return start_date, end_date
+
+def test_get_account(get_client_instance):
+    tenant_name = get_client_instance._tenant.name
+    # Test get billing account details for valid tenant
+    resp = get_client_instance.billing.get_account(tenant_name)
+    assert resp["data"]["tenant"] == tenant_name
+    # Test get billing account details for no tenant (should give result for tenant invoking the request)
+    resp = get_client_instance.billing.get_account()
+    assert resp["data"]["tenant"] == tenant_name
+    # Test get billing account details for invalid tenant
+    with assert_raises(BillingServerError):
+        get_client_instance.billing.get_account("invalid")
+
+def test_update_contact(get_client_instance):
+    contact = {
+        "firstname": "John",
+        "lastname": "Doe",
+        "email": "john@acme.com",
+        "phone": "404-555-8726",
+        "line1": "1388 Villa Drive",
+        "line2": "Suite 240C",
+        "city": "South Bend",
+        "state": "IN",
+        "country": "US",
+        "zipcode": "46601",
+        "bi": "hi"
+    }
+    # Test get billing update contact
+    resp = get_client_instance.billing.update_contact(tenant=get_client_instance._tenant.name, contact=contact)
+    assert resp["data"] == contact
+
+    # Test get billing update contact with invalid tenant
+    with assert_raises(BillingServerError):
+        get_client_instance.billing.update_contact("invalid")
+
+def test_get_previous_payments(get_client_instance):
+    # Test get billing account details for tenant having no stripe account
+    with assert_raises(BillingServerError) as err:
+        get_client_instance.billing.get_previous_payments(months=1)
+    assert "Method Not Allowed" in str(err.value)
+
+def test_get_previous_invoices(get_client_instance):
+    # Test get billing account details for tenant having no stripe account
+    with assert_raises(BillingServerError) as err:
+        get_client_instance.billing.get_previous_invoices(months=1)
+    assert "Method Not Allowed" in str(err.value)
+
+def test_get_current_invoice(get_client_instance):
+    # Test get billing account details for tenant having no stripe account
+    with assert_raises(BillingServerError) as err:
+        get_client_instance.billing.get_current_invoice()
+    assert "Method Not Allowed" in str(err.value)
+
+def test_get_specific_invoice(get_client_instance):
+    # Test get billing account details for tenant having no stripe account
+    with assert_raises(BillingServerError) as err:
+        get_client_instance.billing.get_specific_invoice(year=2022, month=10)
+    assert "Method Not Allowed" in str(err.value)
+
+def test_get_usage(get_client_instance, get_dates):
+    # Test get billing usage
+    start_date, end_date = get_dates
+    resp = get_client_instance.billing.get_usage(start_date=start_date, end_date=end_date)
+    assert resp["data"][0]["tenant"] == get_client_instance._tenant.name
+
+    # Test get billing usage with invalid tenant
+    with assert_raises(BillingServerError) as err:
+        get_client_instance.billing.get_usage("invalid")
+
+def test_get_usage_region(get_client_instance, get_dates):
+    # Test get billing usage
+    start_date, end_date = get_dates
+    region = get_client_instance.get_local_dc(False)
+    resp = get_client_instance.billing.get_usage_region(region=region, start_date=start_date, end_date=end_date)
+    assert resp["data"][0]["tenant"] == get_client_instance._tenant.name
+
+    # Test get billing usage with invalid tenant
+    with assert_raises(BillingServerError) as err:
+        get_client_instance.billing.get_usage_region(region=region, tenant="invalid")

--- a/tests/e2e/test_billing.py
+++ b/tests/e2e/test_billing.py
@@ -32,8 +32,7 @@ def test_update_contact(get_client_instance):
         "city": "South Bend",
         "state": "IN",
         "country": "US",
-        "zipcode": "46601",
-        "bi": "hi"
+        "zipcode": "46601"
     }
     # Test get billing update contact
     resp = get_client_instance.billing.update_contact(tenant=get_client_instance._tenant.name, contact=contact)

--- a/tests/e2e/test_collection.py
+++ b/tests/e2e/test_collection.py
@@ -1,24 +1,24 @@
-from tests.helpers import generate_col_name, clean_doc
+from tests.helpers import generate_col_name
 
 
-def test_create_collection_endpoint(client):
+def test_create_collection_endpoint(client, tst_fabric_name):
     collection_name = generate_col_name()
+    client._tenant.useFabric(tst_fabric_name)
     col = client.create_collection(collection_name)
     assert repr(col) == '<StandardCollection {}>'.format(col.name)
     assert col.tenant_name == client._tenant.name
     assert col.name.startswith('test_collection') == True
 
-
 def test_collection_truncate(sys_fabric, col):
     assert sys_fabric.collection(col.name).truncate() == True
 
 
-def test_collection_doc_count(sys_fabric, col, docs):
+def test_collection_doc_count(col, docs):
     col.insert_many(docs)
     assert col.count() == len(docs)
 
 
-def test_collection_has_doc(sys_fabric, col, docs):
+def test_collection_has_doc(sys_fabric, col):
     doc_id = col.name + '/' + 'foo'
     col.insert({'_id': doc_id})
     assert sys_fabric.collection(col.name).has(doc_id) == True
@@ -36,7 +36,10 @@ def test_collection_export(col, docs):
     assert len(cursor) == 2
 
 
-def test_collection_indexes(col):
+def test_collection_indexes(client, tst_fabric_name):
+    collection_name = generate_col_name()
+    client._tenant.useFabric(tst_fabric_name)
+    col = client.create_collection(collection_name)
     fields = ['lat', 'lng']
     geo_index = col.add_geo_index(fields=fields)
     assert geo_index['fields'] == fields
@@ -75,23 +78,25 @@ def test_collection_indexes(col):
     assert col.delete_index(ttl_index['name']) == True
 
 
-def test_delete_collection_endpoint(client):
+def test_delete_collection_endpoint(client, tst_fabric_name):
     collection_name = generate_col_name()
+    client._tenant.useFabric(tst_fabric_name)
     client.create_collection(collection_name)
     assert client.delete_collection(collection_name) == True
 
 
-def test_has_collection_endpoint(client):
+def test_has_collection_endpoint(client, tst_fabric_name):
     collection_name = generate_col_name()
+    client._tenant.useFabric(tst_fabric_name)
     client.create_collection(collection_name)
     assert True == client.has_collection(collection_name)
     assert False == client.has_collection(generate_col_name())
 
 
-def test_collection_figures(sys_fabric, client):
+def test_collection_figures(client, tst_fabric_name):
     collection_name = generate_col_name()
+    fab = client._tenant.useFabric(tst_fabric_name)
     col = client.create_collection(collection_name, key_generator='autoincrement')
-    fab = client._tenant.useFabric('_system')
     get_col_properties = fab.collection_figures(collection_name=col.name)
     if col.context != 'transaction':
         assert 'id' in get_col_properties

--- a/tests/e2e/test_plans.py
+++ b/tests/e2e/test_plans.py
@@ -1,18 +1,9 @@
-import pytest
-
 from tests.helpers import assert_raises
 from c8.plan.core import PlansServerError
-from conftest import test_data_billing_plan, test_data_update_plan, get_mm_client_instance, \
-    test_update_tenant_billing_plan
+from conftest import test_data_billing_plan, test_data_update_plan, test_update_tenant_billing_plan
 
 
-@pytest.fixture
-def plans_setup_client():
-    client = get_mm_client_instance()
-    return client
-
-
-def test_list_billing_plans(plans_setup_client):
+def test_list_billing_plans(get_mm_client_instance):
     billing_details = test_data_billing_plan()
     billing_plan_name = billing_details['name']
     plan_details = {'planId': billing_details['planId'], 'description': billing_details['description'],
@@ -21,7 +12,7 @@ def test_list_billing_plans(plans_setup_client):
                     'metrics': billing_details['metrics']}
 
     # Test create billing plan
-    resp = plans_setup_client.plan().create_billing_plan(name=billing_details['name'],
+    resp = get_mm_client_instance.plan().create_billing_plan(name=billing_details['name'],
                                                          features_gates=billing_details['featureGates'],
                                                          attribution=billing_details['attribution'],
                                                          label=billing_details['label'],
@@ -31,7 +22,7 @@ def test_list_billing_plans(plans_setup_client):
         assert i in resp
 
     # Test list billing plan details
-    resp = plans_setup_client.plan().list_billing_plan_details(plan_name=billing_plan_name)
+    resp = get_mm_client_instance.plan().list_billing_plan_details(plan_name=billing_plan_name)
     for i in test_data_billing_plan():
         assert i in resp
 
@@ -41,7 +32,7 @@ def test_list_billing_plans(plans_setup_client):
                    'pricing': billing_details_update['pricing'], 'isBundle': billing_details_update['isBundle'],
                    'demo': billing_details_update['demo'],
                    'metrics': billing_details_update['metrics']}
-    resp = plans_setup_client.plan().modify_billing_plan(plan_name=billing_plan_name,
+    resp = get_mm_client_instance.plan().modify_billing_plan(plan_name=billing_plan_name,
                                                          attribution=billing_details_update['attribution'],
                                                          active=billing_details_update['active'],
                                                          label=billing_details_update['label'],
@@ -52,24 +43,24 @@ def test_list_billing_plans(plans_setup_client):
     # Test update tenant billing plan
     update_data = test_update_tenant_billing_plan()
     with assert_raises(PlansServerError) as err:
-        plans_setup_client.plan().update_tenant_billing_plan(attribution=update_data['attribution'],
+        get_mm_client_instance.plan().update_tenant_billing_plan(attribution=update_data['attribution'],
                                                              plan=update_data['plan'],
                                                              payment_method_id=update_data['payment_method_id'],
                                                              tenant=update_data['tenant'])
     assert err.value.error_code == 404
 
     # Test list billing plans
-    resp = plans_setup_client.plan().list_billing_plans()
+    resp = get_mm_client_instance.plan().list_billing_plans()
     for x in range(len(resp)):
         assert 'active' in resp[x]
         assert 'featureGates' in resp[x]
         assert 'name' in resp[x]
 
     # Test remove billing plan
-    resp = plans_setup_client.plan().remove_billing_plan(plan_name=billing_plan_name)
+    resp = get_mm_client_instance.plan().remove_billing_plan(plan_name=billing_plan_name)
     for x in test_data_update_plan():
         assert x in resp
 
-    resp = plans_setup_client.plan().list_billing_plans()
+    resp = get_mm_client_instance.plan().list_billing_plans()
     for x in range(len(resp)):
         assert billing_plan_name not in resp[x]['name']

--- a/tests/e2e/test_redis.py
+++ b/tests/e2e/test_redis.py
@@ -1,6 +1,3 @@
-import pytest
-from conftest import get_client_instance
-
 """
 Tests need to be run in sequence since we first create collection, after that we fill 
 collection with test data data, run tests and check for the results.
@@ -8,15 +5,8 @@ collection with test data data, run tests and check for the results.
 
 REDIS_COLLECTION = "testRedisCollection"
 
-
-@pytest.fixture
-def setup_client():
-    client = get_client_instance()
-    return client
-
-
-def test_create_redis_collection(setup_client):
-    response = setup_client.create_collection(
+def test_create_redis_collection(get_client_instance):
+    response = get_client_instance.create_collection(
         REDIS_COLLECTION,
         stream=True,
     )
@@ -24,93 +14,93 @@ def test_create_redis_collection(setup_client):
     assert REDIS_COLLECTION == response.name
 
 
-def test_redis_set(setup_client):
-    response = setup_client.redis.set("test", "1", REDIS_COLLECTION)
+def test_redis_set(get_client_instance):
+    response = get_client_instance.redis.set("test", "1", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "OK"} == response
 
 
-def test_redis_append(setup_client):
-    response = setup_client.redis.append("test", "2", REDIS_COLLECTION)
+def test_redis_append(get_client_instance):
+    response = get_client_instance.redis.append("test", "2", REDIS_COLLECTION)
     # Response from platform -> Number of strings in values
     assert {"code": 200, "result": 2} == response
 
 
-def test_redis_dec(setup_client):
-    response = setup_client.redis.decr("test", REDIS_COLLECTION)
+def test_redis_dec(get_client_instance):
+    response = get_client_instance.redis.decr("test", REDIS_COLLECTION)
     # Response from platform -> Number of strings in values
     assert {"code": 200, "result": 11} == response
 
 
-def test_redis_decby(setup_client):
-    response = setup_client.redis.decrby("test", 10, REDIS_COLLECTION)
+def test_redis_decby(get_client_instance):
+    response = get_client_instance.redis.decrby("test", 10, REDIS_COLLECTION)
     # Response from platform -> Returned value is int
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_get(setup_client):
-    response = setup_client.redis.get("test", REDIS_COLLECTION)
+def test_redis_get(get_client_instance):
+    response = get_client_instance.redis.get("test", REDIS_COLLECTION)
     # Response from platform -> make sure that we have data on platform "result": "2"
     assert {"code": 200, "result": "1"} == response
 
 
-def test_redis_getdel(setup_client):
-    response = setup_client.redis.getdel("test", REDIS_COLLECTION)
+def test_redis_getdel(get_client_instance):
+    response = get_client_instance.redis.getdel("test", REDIS_COLLECTION)
     # Response from platform -> make sure that we have data on platform "result": "2"
     assert {"code": 200, "result": "1"} == response
 
 
-def test_redis_getex(setup_client):
-    setup_client.redis.set("test", "EX", REDIS_COLLECTION)
-    response = setup_client.redis.getex("test", REDIS_COLLECTION, "EX", "200")
+def test_redis_getex(get_client_instance):
+    get_client_instance.redis.set("test", "EX", REDIS_COLLECTION)
+    response = get_client_instance.redis.getex("test", REDIS_COLLECTION, "EX", "200")
     # Response from platform -> make sure that we have data on platform "result": "2"
     assert {"code": 200, "result": "EX"} == response
 
 
-def test_redis_getrange(setup_client):
-    response = setup_client.redis.getrange("test", 0, 0, REDIS_COLLECTION)
+def test_redis_getrange(get_client_instance):
+    response = get_client_instance.redis.getrange("test", 0, 0, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "E"} == response
 
 
-def test_redis_getset(setup_client):
-    response = setup_client.redis.getset("test", "test_value", REDIS_COLLECTION)
+def test_redis_getset(get_client_instance):
+    response = get_client_instance.redis.getset("test", "test_value", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "EX"} == response
 
 
-def test_redis_incr(setup_client):
-    response = setup_client.redis.incr("test", REDIS_COLLECTION)
+def test_redis_incr(get_client_instance):
+    response = get_client_instance.redis.incr("test", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_incrby(setup_client):
-    response = setup_client.redis.incrby("test", 10, REDIS_COLLECTION)
+def test_redis_incrby(get_client_instance):
+    response = get_client_instance.redis.incrby("test", 10, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 11} == response
 
 
-def test_redis_incrbyfloat(setup_client):
-    response = setup_client.redis.incrbyfloat("test", 0.5, REDIS_COLLECTION)
+def test_redis_incrbyfloat(get_client_instance):
+    response = get_client_instance.redis.incrbyfloat("test", 0.5, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": '11.5'} == response
 
 
-def test_redis_set_2(setup_client):
-    response = setup_client.redis.set("test2", "22", REDIS_COLLECTION)
+def test_redis_set_2(get_client_instance):
+    response = get_client_instance.redis.set("test2", "22", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "OK"} == response
 
 
-def test_redis_mget(setup_client):
-    response = setup_client.redis.mget(["test", "test2"], REDIS_COLLECTION)
+def test_redis_mget(get_client_instance):
+    response = get_client_instance.redis.mget(["test", "test2"], REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["11.5", "22"]} == response
 
 
-def test_redis_mset(setup_client):
-    response = setup_client.redis.mset(
+def test_redis_mset(get_client_instance):
+    response = get_client_instance.redis.mset(
         {"test3": "value3", "test4": "value4"},
         REDIS_COLLECTION
     )
@@ -118,8 +108,8 @@ def test_redis_mset(setup_client):
     assert {"code": 200, "result": "OK"} == response
 
 
-def test_redis_msetnx(setup_client):
-    response = setup_client.redis.msetnx(
+def test_redis_msetnx(get_client_instance):
+    response = get_client_instance.redis.msetnx(
         {"test5": "value5", "test6": "value6"},
         REDIS_COLLECTION
     )
@@ -128,62 +118,62 @@ def test_redis_msetnx(setup_client):
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_setex(setup_client):
-    response = setup_client.redis.setex("ttlKeySec", 30, "value", REDIS_COLLECTION)
+def test_redis_setex(get_client_instance):
+    response = get_client_instance.redis.setex("ttlKeySec", 30, "value", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "OK"} == response
 
 
-def test_redis_psetex(setup_client):
-    response = setup_client.redis.psetex("ttlKeyMs", 30000, "value", REDIS_COLLECTION)
+def test_redis_psetex(get_client_instance):
+    response = get_client_instance.redis.psetex("ttlKeyMs", 30000, "value", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "OK"} == response
 
 
-def test_redis_setbit(setup_client):
-    response = setup_client.redis.setbit("bitKey", 7, 0, REDIS_COLLECTION)
+def test_redis_setbit(get_client_instance):
+    response = get_client_instance.redis.setbit("bitKey", 7, 0, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 0} == response
 
 
-def test_redis_setnx(setup_client):
-    response = setup_client.redis.setnx("testSetNx", "1", REDIS_COLLECTION)
+def test_redis_setnx(get_client_instance):
+    response = get_client_instance.redis.setnx("testSetNx", "1", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_setrange(setup_client):
-    response = setup_client.redis.setrange("testSetNx", 0, "2", REDIS_COLLECTION)
+def test_redis_setrange(get_client_instance):
+    response = get_client_instance.redis.setrange("testSetNx", 0, "2", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_setnx_2(setup_client):
-    response = setup_client.redis.setnx("testString", "string", REDIS_COLLECTION)
+def test_redis_setnx_2(get_client_instance):
+    response = get_client_instance.redis.setnx("testString", "string", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_strlen(setup_client):
-    response = setup_client.redis.strlen("testString", REDIS_COLLECTION)
+def test_redis_strlen(get_client_instance):
+    response = get_client_instance.redis.strlen("testString", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 6} == response
 
 
-def test_redis_setnx_3(setup_client):
-    response = setup_client.redis.setnx("myKeyString", "foobar", REDIS_COLLECTION)
+def test_redis_setnx_3(get_client_instance):
+    response = get_client_instance.redis.setnx("myKeyString", "foobar", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_bitcount(setup_client):
-    response = setup_client.redis.bitcount("myKeyString", REDIS_COLLECTION)
+def test_redis_bitcount(get_client_instance):
+    response = get_client_instance.redis.bitcount("myKeyString", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 26} == response
 
 
-def test_redis_bitcount_2(setup_client):
-    response = setup_client.redis.bitcount("myKeyString", REDIS_COLLECTION, 0, 0)
+def test_redis_bitcount_2(get_client_instance):
+    response = get_client_instance.redis.bitcount("myKeyString", REDIS_COLLECTION, 0, 0)
     # Response from platform
     assert {"code": 200, "result": 4} == response
 
@@ -191,77 +181,77 @@ def test_redis_bitcount_2(setup_client):
 # This test fails
 # We support Redis commands till 6.2, bit/byte operation was added in 7.0
 # def test_redis_bitcount_3():
-#     setup_client = get_client_instance()
+#     get_client_instance = get_client_instance()
 #
-#     response = setup_client.redis_bitcount("myKeyString", REDIS_COLLECTION, 1, 1, "BYTE")
+#     response = get_client_instance.redis_bitcount("myKeyString", REDIS_COLLECTION, 1, 1, "BYTE")
 #     
 #     # Response from platform
 #     assert {"code": 200, "result": 6} == response
 
 
-def test_redis_set_3(setup_client):
-    response = setup_client.redis.set("key1", "foobar", REDIS_COLLECTION)
+def test_redis_set_3(get_client_instance):
+    response = get_client_instance.redis.set("key1", "foobar", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "OK"} == response
 
 
-def test_redis_set_4(setup_client):
-    response = setup_client.redis.set("key2", "abcdef", REDIS_COLLECTION)
+def test_redis_set_4(get_client_instance):
+    response = get_client_instance.redis.set("key2", "abcdef", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "OK"} == response
 
 
-def test_redis_bitop(setup_client):
-    response = setup_client.redis.bitop("AND", "dest", ["key1", "key2"], REDIS_COLLECTION)
+def test_redis_bitop(get_client_instance):
+    response = get_client_instance.redis.bitop("AND", "dest", ["key1", "key2"], REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 6} == response
 
 
-def test_redis_setbit_2(setup_client):
-    response = setup_client.redis.setbit("mykey", 7, 1, REDIS_COLLECTION)
+def test_redis_setbit_2(get_client_instance):
+    response = get_client_instance.redis.setbit("mykey", 7, 1, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 0} == response
 
 
-def test_redis_getbit(setup_client):
-    response = setup_client.redis.getbit("mykey", 7, REDIS_COLLECTION)
+def test_redis_getbit(get_client_instance):
+    response = get_client_instance.redis.getbit("mykey", 7, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_set_5(setup_client):
-    response = setup_client.redis.set("mykey2", '\x00\x00\x00', REDIS_COLLECTION)
+def test_redis_set_5(get_client_instance):
+    response = get_client_instance.redis.set("mykey2", '\x00\x00\x00', REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "OK"} == response
 
 
-def test_redis_bitpos(setup_client):
-    response = setup_client.redis.bitpos("mykey2", 0, REDIS_COLLECTION)
+def test_redis_bitpos(get_client_instance):
+    response = get_client_instance.redis.bitpos("mykey2", 0, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 0} == response
 
 
-def test_redis_bitpos_2(setup_client):
-    response = setup_client.redis.bitpos("mykey2", 1, REDIS_COLLECTION)
+def test_redis_bitpos_2(get_client_instance):
+    response = get_client_instance.redis.bitpos("mykey2", 1, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": -1} == response
 
 
-def test_redis_lpush(setup_client):
+def test_redis_lpush(get_client_instance):
     list_data = ["iron", "gold", "copper"]
-    response = setup_client.redis.lpush("list", list_data, REDIS_COLLECTION)
+    response = get_client_instance.redis.lpush("list", list_data, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 3} == response
 
 
-def test_redis_lindex(setup_client):
-    response = setup_client.redis.lindex("list", 0, REDIS_COLLECTION)
+def test_redis_lindex(get_client_instance):
+    response = get_client_instance.redis.lindex("list", 0, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "copper"} == response
 
 
-def test_redis_linsert(setup_client):
-    response = setup_client.redis.linsert(
+def test_redis_linsert(get_client_instance):
+    response = get_client_instance.redis.linsert(
         "list",
         "AFTER",
         "copper",
@@ -272,34 +262,34 @@ def test_redis_linsert(setup_client):
     assert {"code": 200, "result": 4} == response
 
 
-def test_redis_llen(setup_client):
-    response = setup_client.redis.llen("list", REDIS_COLLECTION)
+def test_redis_llen(get_client_instance):
+    response = get_client_instance.redis.llen("list", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 4} == response
 
 
-def test_redis_lrange(setup_client):
-    response = setup_client.redis.lrange("list", 0, 1, REDIS_COLLECTION)
+def test_redis_lrange(get_client_instance):
+    response = get_client_instance.redis.lrange("list", 0, 1, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["copper", "silver"]} == response
 
 
-def test_redis_lpush_1(setup_client):
+def test_redis_lpush_1(get_client_instance):
     list_data = ["a", "b", "c"]
-    response = setup_client.redis.lpush("testList1", list_data, REDIS_COLLECTION)
+    response = get_client_instance.redis.lpush("testList1", list_data, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 3} == response
 
 
-def test_redis_lpush_2(setup_client):
+def test_redis_lpush_2(get_client_instance):
     list_data = ["x", "y", "z"]
-    response = setup_client.redis.lpush("testList2", list_data, REDIS_COLLECTION)
+    response = get_client_instance.redis.lpush("testList2", list_data, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 3} == response
 
 
-def test_redis_lmove(setup_client):
-    response = setup_client.redis.lmove(
+def test_redis_lmove(get_client_instance):
+    response = get_client_instance.redis.lmove(
         "testList1",
         "testList2",
         "RIGHT",
@@ -310,98 +300,98 @@ def test_redis_lmove(setup_client):
     assert {"code": 200, "result": "a"} == response
 
 
-def test_redis_rpush(setup_client):
+def test_redis_rpush(get_client_instance):
     list_data = ["a", "b", "c", "d", 1, 2, 3, 4, 3, 3, 3]
-    response = setup_client.redis.rpush("testListPos", list_data, REDIS_COLLECTION)
+    response = get_client_instance.redis.rpush("testListPos", list_data, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 11} == response
 
 
-def test_redis_lpos(setup_client):
-    response = setup_client.redis.lpos("testListPos", 3, REDIS_COLLECTION)
+def test_redis_lpos(get_client_instance):
+    response = get_client_instance.redis.lpos("testListPos", 3, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 6} == response
 
 
-def test_redis_lpos_2(setup_client):
-    response = setup_client.redis.lpos("testListPos", 3, REDIS_COLLECTION, 0, 3)
+def test_redis_lpos_2(get_client_instance):
+    response = get_client_instance.redis.lpos("testListPos", 3, REDIS_COLLECTION, 0, 3)
     # Response from platform
     assert {"code": 200, "result": [6, 8, 9]} == response
 
 
-def test_redis_lpop(setup_client):
-    response = setup_client.redis.lpop("testList2", REDIS_COLLECTION, 1)
+def test_redis_lpop(get_client_instance):
+    response = get_client_instance.redis.lpop("testList2", REDIS_COLLECTION, 1)
     # Response from platform
     assert {"code": 200, "result": ["a"]} == response
 
 
-def test_redis_lpushx(setup_client):
+def test_redis_lpushx(get_client_instance):
     list_data = ["a", "b", "c", "d", 1, 2, 3, 4, 3, 3, 3]
-    response = setup_client.redis.lpushx("testListPos", list_data, REDIS_COLLECTION)
+    response = get_client_instance.redis.lpushx("testListPos", list_data, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 22} == response
 
 
-def test_redis_rpush_2(setup_client):
+def test_redis_rpush_2(get_client_instance):
     list_data = ["a", "b", "c", "d", 1, 2, 3, 4, 3, 3, 3]
-    response = setup_client.redis.rpush("testListRpushx", list_data, REDIS_COLLECTION)
+    response = get_client_instance.redis.rpush("testListRpushx", list_data, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 11} == response
 
 
-def test_redis_rpushx(setup_client):
+def test_redis_rpushx(get_client_instance):
     list_data = ["a", "b", "c", "d", 1, 2, 3, 4, 3, 3, 3]
-    response = setup_client.redis.rpushx("testListRpushx", list_data, REDIS_COLLECTION)
+    response = get_client_instance.redis.rpushx("testListRpushx", list_data, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 22} == response
 
 
-def test_redis_rpush_3(setup_client):
+def test_redis_rpush_3(get_client_instance):
     list_data = ["hello", "hello", "foo", "hello"]
-    response = setup_client.redis.rpush("testListLrem", list_data, REDIS_COLLECTION)
+    response = get_client_instance.redis.rpush("testListLrem", list_data, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 4} == response
 
 
-def test_redis_lrem(setup_client):
-    response = setup_client.redis.lrem("testListLrem", -2, "hello", REDIS_COLLECTION)
+def test_redis_lrem(get_client_instance):
+    response = get_client_instance.redis.lrem("testListLrem", -2, "hello", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 2} == response
 
 
-def test_redis_lset(setup_client):
-    response = setup_client.redis.lset("testListLrem", 0, "test", REDIS_COLLECTION)
+def test_redis_lset(get_client_instance):
+    response = get_client_instance.redis.lset("testListLrem", 0, "test", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "OK"} == response
 
 
-def test_redis_trim(setup_client):
-    response = setup_client.redis.ltrim("testListLrem", 0, 0, REDIS_COLLECTION)
+def test_redis_trim(get_client_instance):
+    response = get_client_instance.redis.ltrim("testListLrem", 0, 0, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "OK"} == response
 
 
-def test_redis_rpop(setup_client):
-    response = setup_client.redis.rpop("testListLrem", REDIS_COLLECTION)
+def test_redis_rpop(get_client_instance):
+    response = get_client_instance.redis.rpop("testListLrem", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "test"} == response
 
 
-def test_redis_rpush_4(setup_client):
+def test_redis_rpush_4(get_client_instance):
     list_data = ["one", "two", "three"]
-    response = setup_client.redis.rpush("myPushList", list_data, REDIS_COLLECTION)
+    response = get_client_instance.redis.rpush("myPushList", list_data, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 3} == response
 
 
-def test_redis_rpoplpush(setup_client):
-    response = setup_client.redis.rpoplpush("myPushList", "myOtherPushList", REDIS_COLLECTION)
+def test_redis_rpoplpush(get_client_instance):
+    response = get_client_instance.redis.rpoplpush("myPushList", "myOtherPushList", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "three"} == response
 
 
-def test_redis_hset(setup_client):
-    response = setup_client.redis.hset(
+def test_redis_hset(get_client_instance):
+    response = get_client_instance.redis.hset(
         "games",
         {"action": "elden", "driving": "GT7"},
         REDIS_COLLECTION
@@ -411,56 +401,56 @@ def test_redis_hset(setup_client):
     assert {"code": 200, "result": 2} == response
 
 
-def test_redis_hget(setup_client):
-    response = setup_client.redis.hget("games", "action", REDIS_COLLECTION)
+def test_redis_hget(get_client_instance):
+    response = get_client_instance.redis.hget("games", "action", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "elden"} == response
 
 
-def test_redis_hdel(setup_client):
-    response = setup_client.redis.hdel("games", ["action"], REDIS_COLLECTION)
+def test_redis_hdel(get_client_instance):
+    response = get_client_instance.redis.hdel("games", ["action"], REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_hexists(setup_client):
-    response = setup_client.redis.hexists("games", "driving", REDIS_COLLECTION)
+def test_redis_hexists(get_client_instance):
+    response = get_client_instance.redis.hexists("games", "driving", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_hgetall(setup_client):
-    response = setup_client.redis.hgetall("games", REDIS_COLLECTION)
+def test_redis_hgetall(get_client_instance):
+    response = get_client_instance.redis.hgetall("games", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["driving", "GT7"]} == response
 
 
-def test_redis_hincrby(setup_client):
-    response = setup_client.redis.hincrby("myhash", "field", 5, REDIS_COLLECTION)
+def test_redis_hincrby(get_client_instance):
+    response = get_client_instance.redis.hincrby("myhash", "field", 5, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": '5'} == response
 
 
-def test_redis_hincrbyfloat(setup_client):
-    response = setup_client.redis.hincrbyfloat("myhashfloat", "field", 10.5, REDIS_COLLECTION)
+def test_redis_hincrbyfloat(get_client_instance):
+    response = get_client_instance.redis.hincrbyfloat("myhashfloat", "field", 10.5, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": '10.500000'} == response
 
 
-def test_redis_hkeys(setup_client):
-    response = setup_client.redis.hkeys("games", REDIS_COLLECTION)
+def test_redis_hkeys(get_client_instance):
+    response = get_client_instance.redis.hkeys("games", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["driving"]} == response
 
 
-def test_redis_hlen(setup_client):
-    response = setup_client.redis.hlen("games", REDIS_COLLECTION)
+def test_redis_hlen(get_client_instance):
+    response = get_client_instance.redis.hlen("games", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_hset_2(setup_client):
-    response = setup_client.redis.hset(
+def test_redis_hset_2(get_client_instance):
+    response = get_client_instance.redis.hset(
         "newgames",
         {"action": "elden", "driving": "GT7"},
         REDIS_COLLECTION
@@ -469,14 +459,14 @@ def test_redis_hset_2(setup_client):
     assert {"code": 200, "result": 2} == response
 
 
-def test_redis_hmget(setup_client):
-    response = setup_client.redis.hmget("newgames", ["action", "driving"], REDIS_COLLECTION)
+def test_redis_hmget(get_client_instance):
+    response = get_client_instance.redis.hmget("newgames", ["action", "driving"], REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["elden", "GT7"]} == response
 
 
-def test_redis_hmset(setup_client):
-    response = setup_client.redis.hmset(
+def test_redis_hmset(get_client_instance):
+    response = get_client_instance.redis.hmset(
         "world",
         {"land": "dog", "sea": "octopus"},
         REDIS_COLLECTION
@@ -485,26 +475,26 @@ def test_redis_hmset(setup_client):
     assert {"code": 200, "result": "OK"} == response
 
 
-def test_redis_hmscan_1(setup_client):
-    response = setup_client.redis.hscan("games", 0, REDIS_COLLECTION)
+def test_redis_hmscan_1(get_client_instance):
+    response = get_client_instance.redis.hscan("games", 0, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ['cursor:driving', ['driving', 'GT7']]} == response
 
 
-def test_redis_hmscan_2(setup_client):
-    response = setup_client.redis.hscan("games", 0, REDIS_COLLECTION, "*", 100)
+def test_redis_hmscan_2(get_client_instance):
+    response = get_client_instance.redis.hscan("games", 0, REDIS_COLLECTION, "*", 100)
     # Response from platform
     assert {"code": 200, "result": ["cursor:driving", ["driving", "GT7"]]} == response
 
 
-def test_redis_hstrlen(setup_client):
-    response = setup_client.redis.hstrlen("games", "driving", REDIS_COLLECTION)
+def test_redis_hstrlen(get_client_instance):
+    response = get_client_instance.redis.hstrlen("games", "driving", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 3} == response
 
 
-def test_redis_hmset_2(setup_client):
-    response = setup_client.redis.hmset(
+def test_redis_hmset_2(get_client_instance):
+    response = get_client_instance.redis.hmset(
         "coin",
         {"heads": "obverse", "tails": "reverse", "edge": "null"},
         REDIS_COLLECTION
@@ -514,42 +504,42 @@ def test_redis_hmset_2(setup_client):
     assert {"code": 200, "result": "OK"} == response
 
 
-def test_redis_hrandfield_1(setup_client):
-    response = setup_client.redis.hrandfield("coin", REDIS_COLLECTION)
+def test_redis_hrandfield_1(get_client_instance):
+    response = get_client_instance.redis.hrandfield("coin", REDIS_COLLECTION)
     # Response from platform
     assert 200 == response.get("code")
 
 
-def test_redis_hrandfield_2(setup_client):
-    response = setup_client.redis.hrandfield("coin", REDIS_COLLECTION, -5, "WITHVALUES")
+def test_redis_hrandfield_2(get_client_instance):
+    response = get_client_instance.redis.hrandfield("coin", REDIS_COLLECTION, -5, "WITHVALUES")
     # Response from platform
     assert 200 == response.get("code")
 
 
-def test_redis_hvals(setup_client):
-    response = setup_client.redis.hvals("coin", REDIS_COLLECTION)
+def test_redis_hvals(get_client_instance):
+    response = get_client_instance.redis.hvals("coin", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["obverse", "reverse", "null"]} == response
 
 
-def test_redis_sadd(setup_client):
-    response = setup_client.redis.sadd("animals", ["dog"], REDIS_COLLECTION)
+def test_redis_sadd(get_client_instance):
+    response = get_client_instance.redis.sadd("animals", ["dog"], REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_scard(setup_client):
-    response = setup_client.redis.scard("animals", REDIS_COLLECTION)
+def test_redis_scard(get_client_instance):
+    response = get_client_instance.redis.scard("animals", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_sdiff(setup_client):
+def test_redis_sdiff(get_client_instance):
     # Test Setup according to Redis docs
-    setup_client.redis.sadd("key1sdiff", ["a", "b", "c"], REDIS_COLLECTION)
-    setup_client.redis.sadd("key2sdiff", ["c"], REDIS_COLLECTION)
-    setup_client.redis.sadd("key3sdiff", ["d", "e"], REDIS_COLLECTION)
-    response = setup_client.redis.sdiff(
+    get_client_instance.redis.sadd("key1sdiff", ["a", "b", "c"], REDIS_COLLECTION)
+    get_client_instance.redis.sadd("key2sdiff", ["c"], REDIS_COLLECTION)
+    get_client_instance.redis.sadd("key3sdiff", ["d", "e"], REDIS_COLLECTION)
+    response = get_client_instance.redis.sdiff(
         ["key1sdiff", "key2sdiff", "key3sdiff"],
         REDIS_COLLECTION
     )
@@ -557,8 +547,8 @@ def test_redis_sdiff(setup_client):
     assert {"code": 200, "result": ["b", "a"]} == response
 
 
-def test_redis_sdiffstore(setup_client):
-    response = setup_client.redis.sdiffstore(
+def test_redis_sdiffstore(get_client_instance):
+    response = get_client_instance.redis.sdiffstore(
         "destinationKeysdiffstore",
         ["key1sdiff", "key2sdiff", "key3sdiff"],
         REDIS_COLLECTION
@@ -567,17 +557,17 @@ def test_redis_sdiffstore(setup_client):
     assert {"code": 200, "result": 2} == response
 
 
-def test_redis_sinter(setup_client):
+def test_redis_sinter(get_client_instance):
     # Test Setup according to Redis docs
-    setup_client.redis.sadd("key11", ["a", "b", "c"], REDIS_COLLECTION)
-    setup_client.redis.sadd("key22", ["c", "d", "e"], REDIS_COLLECTION)
-    response = setup_client.redis.sinter(["key11", "key22"], REDIS_COLLECTION)
+    get_client_instance.redis.sadd("key11", ["a", "b", "c"], REDIS_COLLECTION)
+    get_client_instance.redis.sadd("key22", ["c", "d", "e"], REDIS_COLLECTION)
+    response = get_client_instance.redis.sinter(["key11", "key22"], REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["c"]} == response
 
 
-def test_redis_sinterstore(setup_client):
-    response = setup_client.redis.sinterstore(
+def test_redis_sinterstore(get_client_instance):
+    response = get_client_instance.redis.sinterstore(
         "destinationInter",
         ["key11", "key22"],
         REDIS_COLLECTION
@@ -586,86 +576,86 @@ def test_redis_sinterstore(setup_client):
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_sismember(setup_client):
+def test_redis_sismember(get_client_instance):
     # Test Setup according to Redis docs
-    response = setup_client.redis.sismember("key11", "a", REDIS_COLLECTION)
+    response = get_client_instance.redis.sismember("key11", "a", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_smembers(setup_client):
+def test_redis_smembers(get_client_instance):
     # Test Setup according to Redis docs
-    response = setup_client.redis.smembers("key11", REDIS_COLLECTION)
+    response = get_client_instance.redis.smembers("key11", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["a", "b", "c"]} == response
 
 
-def test_redis_smismember(setup_client):
+def test_redis_smismember(get_client_instance):
     # Test Setup according to Redis docs
-    response = setup_client.redis.smismember("key11", ["a", "b", "z"], REDIS_COLLECTION)
+    response = get_client_instance.redis.smismember("key11", ["a", "b", "z"], REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": [1, 1, 0]} == response
 
 
-def test_redis_smove(setup_client):
+def test_redis_smove(get_client_instance):
     # Test Setup according to Redis docs
-    response = setup_client.redis.smove("key11", "key22", "b", REDIS_COLLECTION)
+    response = get_client_instance.redis.smove("key11", "key22", "b", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_spop(setup_client):
-    response = setup_client.redis.spop("animals", 1, REDIS_COLLECTION)
+def test_redis_spop(get_client_instance):
+    response = get_client_instance.redis.spop("animals", 1, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ['dog']} == response
 
 
-def test_redis_srandmember_1(setup_client):
+def test_redis_srandmember_1(get_client_instance):
     # Test Setup according to Redis docs
-    response = setup_client.redis.srandmember("key22", REDIS_COLLECTION)
+    response = get_client_instance.redis.srandmember("key22", REDIS_COLLECTION)
     # Response from platform
     assert 200 == response.get("code")
 
 
-def test_redis_srandmember_2(setup_client):
+def test_redis_srandmember_2(get_client_instance):
     # Test Setup according to Redis docs
-    response = setup_client.redis.srandmember("key22", REDIS_COLLECTION, -5)
+    response = get_client_instance.redis.srandmember("key22", REDIS_COLLECTION, -5)
     # Response from platform
     assert 200 == response.get("code")
 
 
-def test_redis_srem(setup_client):
+def test_redis_srem(get_client_instance):
     # Test Setup according to Redis docs
-    response = setup_client.redis.srem("key22", ["e", "b"], REDIS_COLLECTION)
+    response = get_client_instance.redis.srem("key22", ["e", "b"], REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 2} == response
 
 
-def test_redis_sscan_1(setup_client):
-    setup_client.redis.sadd("keyScan", ["a", "b", "c"], REDIS_COLLECTION)
-    response = setup_client.redis.sscan("keyScan", 0, REDIS_COLLECTION)
+def test_redis_sscan_1(get_client_instance):
+    get_client_instance.redis.sadd("keyScan", ["a", "b", "c"], REDIS_COLLECTION)
+    response = get_client_instance.redis.sscan("keyScan", 0, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["cursor:c", ["a", "b", "c"]]} == response
 
 
-def test_redis_sscan_2(setup_client):
-    response = setup_client.redis.sscan("keyScan", 0, REDIS_COLLECTION, "*", 100)
+def test_redis_sscan_2(get_client_instance):
+    response = get_client_instance.redis.sscan("keyScan", 0, REDIS_COLLECTION, "*", 100)
     # Response from platform
     assert {"code": 200, "result": ["cursor:c", ["a", "b", "c"]]} == response
 
 
-def test_redis_sunion(setup_client):
+def test_redis_sunion(get_client_instance):
     # Test Setup according to Redis docs
-    setup_client.redis.sadd("key111", ["a", "b", "c"], REDIS_COLLECTION)
-    setup_client.redis.sadd("key222", ["c", "d", "e"], REDIS_COLLECTION)
-    response = setup_client.redis.sunion(["key111", "key222"], REDIS_COLLECTION)
+    get_client_instance.redis.sadd("key111", ["a", "b", "c"], REDIS_COLLECTION)
+    get_client_instance.redis.sadd("key222", ["c", "d", "e"], REDIS_COLLECTION)
+    response = get_client_instance.redis.sunion(["key111", "key222"], REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["a", "b", "c", "d", "e"]} == response
 
 
-def test_redis_sunionstore(setup_client):
+def test_redis_sunionstore(get_client_instance):
     # Test Setup according to Redis docs
-    response = setup_client.redis.sunionstore(
+    response = get_client_instance.redis.sunionstore(
         "destinationUnionStore",
         ["key111", "key222"],
         REDIS_COLLECTION
@@ -674,14 +664,14 @@ def test_redis_sunionstore(setup_client):
     assert {"code": 200, "result": 5} == response
 
 
-def test_redis_zadd(setup_client):
-    response = setup_client.redis.zadd("testZadd", [1, "test"], REDIS_COLLECTION)
+def test_redis_zadd(get_client_instance):
+    response = get_client_instance.redis.zadd("testZadd", [1, "test"], REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_zadd_2(setup_client):
-    response = setup_client.redis.zadd(
+def test_redis_zadd_2(get_client_instance):
+    response = get_client_instance.redis.zadd(
         "testZadd2",
         [1, "test2"],
         REDIS_COLLECTION,
@@ -691,37 +681,37 @@ def test_redis_zadd_2(setup_client):
     assert {"code": 200, "result": "1"} == response
 
 
-def test_redis_zrange(setup_client):
-    response = setup_client.redis.zrange("testZadd", 0, 1, REDIS_COLLECTION)
+def test_redis_zrange(get_client_instance):
+    response = get_client_instance.redis.zrange("testZadd", 0, 1, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["test"]} == response
 
 
-def test_redis_zrange_2(setup_client):
-    response = setup_client.redis.zrange("testZadd", 0, 1, REDIS_COLLECTION, ["WITHSCORES"])
+def test_redis_zrange_2(get_client_instance):
+    response = get_client_instance.redis.zrange("testZadd", 0, 1, REDIS_COLLECTION, ["WITHSCORES"])
     # Response from platform
     assert {"code": 200, "result": ["test", 1]} == response
 
 
-def test_redis_zcard(setup_client):
-    response = setup_client.redis.zcard("testZadd", REDIS_COLLECTION)
+def test_redis_zcard(get_client_instance):
+    response = get_client_instance.redis.zcard("testZadd", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_zcount(setup_client):
-    response = setup_client.redis.zcount("testZadd", 0, 2, REDIS_COLLECTION)
+def test_redis_zcount(get_client_instance):
+    response = get_client_instance.redis.zcount("testZadd", 0, 2, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_zdiff(setup_client):
-    setup_client.redis.zadd("testDiff1", [1, "one"], REDIS_COLLECTION)
-    setup_client.redis.zadd("testDiff1", [2, "two"], REDIS_COLLECTION)
-    setup_client.redis.zadd("testDiff1", [3, "three"], REDIS_COLLECTION)
-    setup_client.redis.zadd("testDiff2", [1, "one"], REDIS_COLLECTION)
-    setup_client.redis.zadd("testDiff2", [2, "two"], REDIS_COLLECTION)
-    response = setup_client.redis.zdiff(
+def test_redis_zdiff(get_client_instance):
+    get_client_instance.redis.zadd("testDiff1", [1, "one"], REDIS_COLLECTION)
+    get_client_instance.redis.zadd("testDiff1", [2, "two"], REDIS_COLLECTION)
+    get_client_instance.redis.zadd("testDiff1", [3, "three"], REDIS_COLLECTION)
+    get_client_instance.redis.zadd("testDiff2", [1, "one"], REDIS_COLLECTION)
+    get_client_instance.redis.zadd("testDiff2", [2, "two"], REDIS_COLLECTION)
+    response = get_client_instance.redis.zdiff(
         2,
         ["testDiff1", "testDiff2"],
         REDIS_COLLECTION)
@@ -729,8 +719,8 @@ def test_redis_zdiff(setup_client):
     assert {"code": 200, "result": ["three"]} == response
 
 
-def test_redis_zdiff_2(setup_client):
-    response = setup_client.redis.zdiff(
+def test_redis_zdiff_2(get_client_instance):
+    response = get_client_instance.redis.zdiff(
         2,
         ["testDiff1", "testDiff2"],
         REDIS_COLLECTION,
@@ -740,8 +730,8 @@ def test_redis_zdiff_2(setup_client):
     assert {"code": 200, "result": ["three", 3]} == response
 
 
-def test_redis_zdiffstore(setup_client):
-    response = setup_client.redis.zdiffstore(
+def test_redis_zdiffstore(get_client_instance):
+    response = get_client_instance.redis.zdiffstore(
         "destinationZdiff",
         2,
         ["testDiff1", "testDiff2"],
@@ -751,22 +741,22 @@ def test_redis_zdiffstore(setup_client):
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_zincrby(setup_client):
-    response = setup_client.redis.zincrby("testZadd", 1.5, "test", REDIS_COLLECTION)
+def test_redis_zincrby(get_client_instance):
+    response = get_client_instance.redis.zincrby("testZadd", 1.5, "test", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 2.5} == response
 
 
-def test_redis_zinter(setup_client):
-    setup_client.redis.zadd("zset1", [1, "one", 2, "two"], REDIS_COLLECTION)
-    setup_client.redis.zadd("zset2", [1, "one", 2, "two", 3, "three"], REDIS_COLLECTION)
-    response = setup_client.redis.zinter(2, ["zset1", "zset2"], REDIS_COLLECTION)
+def test_redis_zinter(get_client_instance):
+    get_client_instance.redis.zadd("zset1", [1, "one", 2, "two"], REDIS_COLLECTION)
+    get_client_instance.redis.zadd("zset2", [1, "one", 2, "two", 3, "three"], REDIS_COLLECTION)
+    response = get_client_instance.redis.zinter(2, ["zset1", "zset2"], REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["one", "two"]} == response
 
 
-def test_redis_zinter_2(setup_client):
-    response = setup_client.redis.zinter(
+def test_redis_zinter_2(get_client_instance):
+    response = get_client_instance.redis.zinter(
         2,
         ["zset1", "zset2"],
         REDIS_COLLECTION,
@@ -776,8 +766,8 @@ def test_redis_zinter_2(setup_client):
     assert {"code": 200, "result": ["one", 2, "two", 4]} == response
 
 
-def test_redis_zinterstore(setup_client):
-    response = setup_client.redis.zinterstore(
+def test_redis_zinterstore(get_client_instance):
+    response = get_client_instance.redis.zinterstore(
         "zinterStore",
         2,
         ["zset1", "zset2"],
@@ -787,60 +777,60 @@ def test_redis_zinterstore(setup_client):
     assert {"code": 200, "result": 2} == response
 
 
-def test_redis_zlexcount(setup_client):
-    setup_client.redis.zadd(
+def test_redis_zlexcount(get_client_instance):
+    get_client_instance.redis.zadd(
         "zlexSet1", [0, "a", 0, "b", 0, "c", 0, "d", 0, "e"],
         REDIS_COLLECTION
     )
-    setup_client.redis.zadd("zlexSet1", [0, "f", 0, "g"], REDIS_COLLECTION)
-    response = setup_client.redis.zlexcount("zlexSet1", "-", "+", REDIS_COLLECTION)
+    get_client_instance.redis.zadd("zlexSet1", [0, "f", 0, "g"], REDIS_COLLECTION)
+    response = get_client_instance.redis.zlexcount("zlexSet1", "-", "+", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 7} == response
 
 
-def test_redis_zmscore(setup_client):
-    response = setup_client.redis.zmscore("zlexSet1", ["a", "b"], REDIS_COLLECTION)
+def test_redis_zmscore(get_client_instance):
+    response = get_client_instance.redis.zmscore("zlexSet1", ["a", "b"], REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": [0, 0]} == response
 
 
-def test_redis_zpopmax(setup_client):
-    setup_client.redis.zadd("zpop", [1, "one", 2, "two", 3, "three"], REDIS_COLLECTION)
-    response = setup_client.redis.zpopmax("zpop", REDIS_COLLECTION)
+def test_redis_zpopmax(get_client_instance):
+    get_client_instance.redis.zadd("zpop", [1, "one", 2, "two", 3, "three"], REDIS_COLLECTION)
+    response = get_client_instance.redis.zpopmax("zpop", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["three", "3"]} == response
 
 
-def test_redis_zpopmin(setup_client):
-    setup_client.redis.zadd("zpop", [1, "one", 2, "two", 3, "three"], REDIS_COLLECTION)
-    response = setup_client.redis.zpopmin("zpop", REDIS_COLLECTION)
+def test_redis_zpopmin(get_client_instance):
+    get_client_instance.redis.zadd("zpop", [1, "one", 2, "two", 3, "three"], REDIS_COLLECTION)
+    response = get_client_instance.redis.zpopmin("zpop", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["one", "1"]} == response
 
 
-def test_redis_zrandmember(setup_client):
-    response = setup_client.redis.zrandmember("zpop", REDIS_COLLECTION)
+def test_redis_zrandmember(get_client_instance):
+    response = get_client_instance.redis.zrandmember("zpop", REDIS_COLLECTION)
     # Response from platform
     assert 200 == response.get("code")
 
 
-def test_redis_zrangebylex(setup_client):
-    setup_client.redis.zadd(
+def test_redis_zrangebylex(get_client_instance):
+    get_client_instance.redis.zadd(
         "zrangeByLexSet1", [0, "a", 0, "b", 0, "c", 0, "d", 0, "e", 0, "f", 0, "g"],
         REDIS_COLLECTION
     )
-    response = setup_client.redis.zrangebylex("zrangeByLexSet1", "-", "[c", REDIS_COLLECTION)
+    response = get_client_instance.redis.zrangebylex("zrangeByLexSet1", "-", "[c", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["a", "b", "c"]} == response
 
 
-def test_redis_zrangebyscore(setup_client):
-    setup_client.redis.zadd(
+def test_redis_zrangebyscore(get_client_instance):
+    get_client_instance.redis.zadd(
         "zrangeByScoreSet1",
         [1, "one", 2, "two", 3, "three"],
         REDIS_COLLECTION
     )
-    response = setup_client.redis.zrangebyscore(
+    response = get_client_instance.redis.zrangebyscore(
         "zrangeByScoreSet1",
         "-inf",
         "+inf",
@@ -850,14 +840,14 @@ def test_redis_zrangebyscore(setup_client):
     assert {"code": 200, "result": ["one", "two", "three"]} == response
 
 
-def test_redis_zrank(setup_client):
-    response = setup_client.redis.zrank("zrangeByScoreSet1", "three", REDIS_COLLECTION)
+def test_redis_zrank(get_client_instance):
+    response = get_client_instance.redis.zrank("zrangeByScoreSet1", "three", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 2} == response
 
 
-def test_redis_zrem(setup_client):
-    response = setup_client.redis.zrem(
+def test_redis_zrem(get_client_instance):
+    response = get_client_instance.redis.zrem(
         "zrangeByScoreSet1",
         ["two", "three"],
         REDIS_COLLECTION
@@ -866,16 +856,16 @@ def test_redis_zrem(setup_client):
     assert {"code": 200, "result": 2} == response
 
 
-def test_redis_zremrangebylex(setup_client):
-    setup_client.redis.zadd(
+def test_redis_zremrangebylex(get_client_instance):
+    get_client_instance.redis.zadd(
         "zremrangebylex", [0, "aaaaa", 0, "b", 0, "c", 0, "d", 0, "e"],
         REDIS_COLLECTION
     )
-    setup_client.redis.zadd(
+    get_client_instance.redis.zadd(
         "zremrangebylex", [0, "foo", 0, "zap", 0, "zip", 0, "ALPHA", 0, "alpha"],
         REDIS_COLLECTION
     )
-    response = setup_client.redis.zremrangebylex(
+    response = get_client_instance.redis.zremrangebylex(
         "zremrangebylex",
         "[alpha",
         "[omega",
@@ -885,12 +875,12 @@ def test_redis_zremrangebylex(setup_client):
     assert {"code": 200, "result": 6} == response
 
 
-def test_redis_zremrangebyrank(setup_client):
-    setup_client.redis.zadd(
+def test_redis_zremrangebyrank(get_client_instance):
+    get_client_instance.redis.zadd(
         "zremrangebyrank", [1, "one", 2, "two", 3, "three"],
         REDIS_COLLECTION
     )
-    response = setup_client.redis.zremrangebyrank(
+    response = get_client_instance.redis.zremrangebyrank(
         "zremrangebyrank",
         0,
         1,
@@ -900,12 +890,12 @@ def test_redis_zremrangebyrank(setup_client):
     assert {"code": 200, "result": 2} == response
 
 
-def test_redis_zremrangebyscore(setup_client):
-    setup_client.redis.zadd(
+def test_redis_zremrangebyscore(get_client_instance):
+    get_client_instance.redis.zadd(
         "zremrangebyscore2", [1, "one", 2, "two", 3, "three"],
         REDIS_COLLECTION
     )
-    response = setup_client.redis.zremrangebyscore(
+    response = get_client_instance.redis.zremrangebyscore(
         "zremrangebyscore2",
         "-inf",
         "(2",
@@ -915,34 +905,34 @@ def test_redis_zremrangebyscore(setup_client):
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_zrevrange(setup_client):
-    setup_client.redis.zadd(
+def test_redis_zrevrange(get_client_instance):
+    get_client_instance.redis.zadd(
         "zrevrange", [1, "one", 2, "two", 3, "three"],
         REDIS_COLLECTION
     )
-    response = setup_client.redis.zrevrange("zrevrange", 0, -1, REDIS_COLLECTION)
+    response = get_client_instance.redis.zrevrange("zrevrange", 0, -1, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["three", "two", "one"]} == response
 
 
-def test_redis_zrevrangebylex(setup_client):
-    setup_client.redis.zadd(
+def test_redis_zrevrangebylex(get_client_instance):
+    get_client_instance.redis.zadd(
         "zrevrangebylex", [0, "a", 0, "b", 0, "c", 0, "d", 0, "e", 0, "f", 0, "g"],
         REDIS_COLLECTION
     )
-    response = setup_client.redis.zrevrangebylex("zrevrangebylex", "[c", "-",
+    response = get_client_instance.redis.zrevrangebylex("zrevrangebylex", "[c", "-",
                                            REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["c", "b", "a"]} == response
 
 
-def test_redis_zrevrangebyscore(setup_client):
-    setup_client.redis.zadd(
+def test_redis_zrevrangebyscore(get_client_instance):
+    get_client_instance.redis.zadd(
         "zrevrangebyscore",
         [1, "one", 2, "two", 3, "three"],
         REDIS_COLLECTION
     )
-    response = setup_client.redis.zrevrangebyscore(
+    response = get_client_instance.redis.zrevrangebyscore(
         "zrevrangebyscore",
         "+inf",
         "-inf",
@@ -952,14 +942,14 @@ def test_redis_zrevrangebyscore(setup_client):
     assert {"code": 200, "result": ["three", "two", "one"]} == response
 
 
-def test_redis_zrevrank(setup_client):
-    response = setup_client.redis.zrevrank("zrevrangebyscore", "one", REDIS_COLLECTION)
+def test_redis_zrevrank(get_client_instance):
+    response = get_client_instance.redis.zrevrank("zrevrangebyscore", "one", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 2} == response
 
 
-def test_redis_zscan(setup_client):
-    response = setup_client.redis.zscan("zrevrangebyscore", 0, REDIS_COLLECTION)
+def test_redis_zscan(get_client_instance):
+    response = get_client_instance.redis.zscan("zrevrangebyscore", 0, REDIS_COLLECTION)
     # Response from platform
     assert {
                "code": 200,
@@ -970,22 +960,22 @@ def test_redis_zscan(setup_client):
            } == response
 
 
-def test_redis_zscore(setup_client):
-    response = setup_client.redis.zscore("zrevrangebyscore", "one", REDIS_COLLECTION)
+def test_redis_zscore(get_client_instance):
+    response = get_client_instance.redis.zscore("zrevrangebyscore", "one", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_zunion(setup_client):
-    setup_client.redis.zadd("zunionSet1", [1, "one", 2, "two"], REDIS_COLLECTION)
-    setup_client.redis.zadd("zunionSet2", [1, "one", 2, "two", 3, "three"], REDIS_COLLECTION)
-    response = setup_client.redis.zunion(2, ["zunionSet1", "zunionSet2"], REDIS_COLLECTION)
+def test_redis_zunion(get_client_instance):
+    get_client_instance.redis.zadd("zunionSet1", [1, "one", 2, "two"], REDIS_COLLECTION)
+    get_client_instance.redis.zadd("zunionSet2", [1, "one", 2, "two", 3, "three"], REDIS_COLLECTION)
+    response = get_client_instance.redis.zunion(2, ["zunionSet1", "zunionSet2"], REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": ["one", "three", "two"]} == response
 
 
-def test_redis_zunion_2(setup_client):
-    response = setup_client.redis.zunion(
+def test_redis_zunion_2(get_client_instance):
+    response = get_client_instance.redis.zunion(
         2,
         ["zunionSet1", "zunionSet2"],
         REDIS_COLLECTION,
@@ -995,14 +985,14 @@ def test_redis_zunion_2(setup_client):
     assert {"code": 200, "result": ["one", 2, "three", 3, "two", 4]} == response
 
 
-def test_redis_zunionstore(setup_client):
-    setup_client.redis.zadd("zunionStoreSet1", [1, "one", 2, "two"], REDIS_COLLECTION)
-    setup_client.redis.zadd(
+def test_redis_zunionstore(get_client_instance):
+    get_client_instance.redis.zadd("zunionStoreSet1", [1, "one", 2, "two"], REDIS_COLLECTION)
+    get_client_instance.redis.zadd(
         "zunionStoreSet2",
         [1, "one", 2, "two", 3, "three"],
         REDIS_COLLECTION
     )
-    response = setup_client.redis.zunionstore(
+    response = get_client_instance.redis.zunionstore(
         "zunionDestination",
         2,
         ["zunionStoreSet1", "zunionStoreSet2"],
@@ -1012,185 +1002,185 @@ def test_redis_zunionstore(setup_client):
     assert {"code": 200, "result": 3} == response
 
 
-def test_redis_copy(setup_client):
-    setup_client.redis.set("dolly", "sheep", REDIS_COLLECTION)
-    response = setup_client.redis.copy("dolly", "clone", REDIS_COLLECTION)
+def test_redis_copy(get_client_instance):
+    get_client_instance.redis.set("dolly", "sheep", REDIS_COLLECTION)
+    response = get_client_instance.redis.copy("dolly", "clone", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_exists(setup_client):
-    response = setup_client.redis.exists(["dolly", "clone"], REDIS_COLLECTION)
+def test_redis_exists(get_client_instance):
+    response = get_client_instance.redis.exists(["dolly", "clone"], REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 2} == response
 
 
-def test_redis_delete(setup_client):
-    response = setup_client.redis.delete(["dolly", "clone"], REDIS_COLLECTION)
+def test_redis_delete(get_client_instance):
+    response = get_client_instance.redis.delete(["dolly", "clone"], REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 2} == response
 
 
-def test_redis_expire(setup_client):
-    setup_client.redis.set("expire", "test", REDIS_COLLECTION)
-    response = setup_client.redis.expire("expire", 30, REDIS_COLLECTION)
+def test_redis_expire(get_client_instance):
+    get_client_instance.redis.set("expire", "test", REDIS_COLLECTION)
+    response = get_client_instance.redis.expire("expire", 30, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_expire_2(setup_client):
-    setup_client.redis.set("expire2", "test", REDIS_COLLECTION)
-    response = setup_client.redis.expire("expire2", 30, REDIS_COLLECTION, "NX")
+def test_redis_expire_2(get_client_instance):
+    get_client_instance.redis.set("expire2", "test", REDIS_COLLECTION)
+    response = get_client_instance.redis.expire("expire2", 30, REDIS_COLLECTION, "NX")
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_expireat(setup_client):
-    setup_client.redis.set("expireat", "test", REDIS_COLLECTION)
-    response = setup_client.redis.expireat("expireat", 30, REDIS_COLLECTION)
+def test_redis_expireat(get_client_instance):
+    get_client_instance.redis.set("expireat", "test", REDIS_COLLECTION)
+    response = get_client_instance.redis.expireat("expireat", 30, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_expireat_2(setup_client):
-    setup_client.redis.set("expireat2", "test", REDIS_COLLECTION)
-    response = setup_client.redis.expireat("expireat2", 30, REDIS_COLLECTION, "NX")
+def test_redis_expireat_2(get_client_instance):
+    get_client_instance.redis.set("expireat2", "test", REDIS_COLLECTION)
+    response = get_client_instance.redis.expireat("expireat2", 30, REDIS_COLLECTION, "NX")
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_persist(setup_client):
-    response = setup_client.redis.persist("expireat2", REDIS_COLLECTION)
+def test_redis_persist(get_client_instance):
+    response = get_client_instance.redis.persist("expireat2", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
 def test_redis_pexpire():
-    setup_client = get_client_instance()
-    setup_client.redis.set("pexpire", "test", REDIS_COLLECTION)
-    response = setup_client.redis.pexpire("pexpire", 8000, REDIS_COLLECTION)
+    get_client_instance = get_client_instance()
+    get_client_instance.redis.set("pexpire", "test", REDIS_COLLECTION)
+    response = get_client_instance.redis.pexpire("pexpire", 8000, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_pexpire_2(setup_client):
-    setup_client.redis.set("pexpire2", "test", REDIS_COLLECTION)
-    response = setup_client.redis.pexpire("pexpire2", 8000, REDIS_COLLECTION, "NX")
+def test_redis_pexpire_2(get_client_instance):
+    get_client_instance.redis.set("pexpire2", "test", REDIS_COLLECTION)
+    response = get_client_instance.redis.pexpire("pexpire2", 8000, REDIS_COLLECTION, "NX")
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_pexpireat(setup_client):
-    setup_client.redis.set("pexpireat", "test", REDIS_COLLECTION)
-    response = setup_client.redis.pexpire("pexpireat", 8000, REDIS_COLLECTION)
+def test_redis_pexpireat(get_client_instance):
+    get_client_instance.redis.set("pexpireat", "test", REDIS_COLLECTION)
+    response = get_client_instance.redis.pexpire("pexpireat", 8000, REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_pexpireat_2(setup_client):
-    setup_client.redis.set("pexpireat2", "test", REDIS_COLLECTION)
-    response = setup_client.redis.pexpire("pexpireat2", 8000, REDIS_COLLECTION, "NX")
+def test_redis_pexpireat_2(get_client_instance):
+    get_client_instance.redis.set("pexpireat2", "test", REDIS_COLLECTION)
+    response = get_client_instance.redis.pexpire("pexpireat2", 8000, REDIS_COLLECTION, "NX")
     # Response from platform
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_pttl(setup_client):
-    setup_client.redis.set("pttl", "test", REDIS_COLLECTION)
-    response = setup_client.redis.pttl("pttl", REDIS_COLLECTION)
+def test_redis_pttl(get_client_instance):
+    get_client_instance.redis.set("pttl", "test", REDIS_COLLECTION)
+    response = get_client_instance.redis.pttl("pttl", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": -1} == response
 
 
-def test_redis_randomkey(setup_client):
-    response = setup_client.redis.randomkey(REDIS_COLLECTION)
+def test_redis_randomkey(get_client_instance):
+    response = get_client_instance.redis.randomkey(REDIS_COLLECTION)
     # Response from platform
     assert 200 == response.get("code")
 
 
-def test_redis_rename(setup_client):
-    setup_client.redis.set("rename", "test", REDIS_COLLECTION)
-    response = setup_client.redis.rename("rename", "newName", REDIS_COLLECTION)
+def test_redis_rename(get_client_instance):
+    get_client_instance.redis.set("rename", "test", REDIS_COLLECTION)
+    response = get_client_instance.redis.rename("rename", "newName", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "OK"} == response
 
 
-def test_redis_scan(setup_client):
-    response = setup_client.redis.scan(0, REDIS_COLLECTION)
+def test_redis_scan(get_client_instance):
+    response = get_client_instance.redis.scan(0, REDIS_COLLECTION)
     # Response from platform
     assert 200 == response.get("code")
 
 
-def test_redis_scan_2(setup_client):
-    response = setup_client.redis.scan(0, REDIS_COLLECTION, "*", 100)
+def test_redis_scan_2(get_client_instance):
+    response = get_client_instance.redis.scan(0, REDIS_COLLECTION, "*", 100)
     # Response from platform
     assert 200 == response.get("code")
 
 
-def test_redis_ttl(setup_client):
-    setup_client.redis.set("ttl", "test", REDIS_COLLECTION)
-    response = setup_client.redis.ttl("ttl", REDIS_COLLECTION)
+def test_redis_ttl(get_client_instance):
+    get_client_instance.redis.set("ttl", "test", REDIS_COLLECTION)
+    response = get_client_instance.redis.ttl("ttl", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": -1} == response
 
 
-def test_redis_type(setup_client):
-    setup_client.redis.set("type", "test", REDIS_COLLECTION)
-    response = setup_client.redis.type("type", REDIS_COLLECTION)
+def test_redis_type(get_client_instance):
+    get_client_instance.redis.set("type", "test", REDIS_COLLECTION)
+    response = get_client_instance.redis.type("type", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "string"} == response
 
 
-def test_redis_unlink(setup_client):
-    setup_client.redis.set("unlink1", "test", REDIS_COLLECTION)
-    setup_client.redis.set("unlink2", "test", REDIS_COLLECTION)
-    response = setup_client.redis.unlink(["unlink1", "unlink2"], REDIS_COLLECTION)
+def test_redis_unlink(get_client_instance):
+    get_client_instance.redis.set("unlink1", "test", REDIS_COLLECTION)
+    get_client_instance.redis.set("unlink2", "test", REDIS_COLLECTION)
+    response = get_client_instance.redis.unlink(["unlink1", "unlink2"], REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": 2} == response
 
 
-def test_redis_echo(setup_client):
-    response = setup_client.redis.echo("Hello World!", REDIS_COLLECTION)
+def test_redis_echo(get_client_instance):
+    response = get_client_instance.redis.echo("Hello World!", REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "Hello World!"} == response
 
 
-def test_redis_ping(setup_client):
-    response = setup_client.redis.ping(REDIS_COLLECTION)
+def test_redis_ping(get_client_instance):
+    response = get_client_instance.redis.ping(REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "PONG"} == response
 
 
-def test_redis_ping_2(setup_client):
-    response = setup_client.redis.ping(REDIS_COLLECTION, "Hello World!")
+def test_redis_ping_2(get_client_instance):
+    response = get_client_instance.redis.ping(REDIS_COLLECTION, "Hello World!")
     # Response from platform
     assert {"code": 200, "result": "Hello World!"} == response
 
 
-def test_redis_dbsize(setup_client):
-    response = setup_client.redis.dbsize(REDIS_COLLECTION)
+def test_redis_dbsize(get_client_instance):
+    response = get_client_instance.redis.dbsize(REDIS_COLLECTION)
     # Response from platform
     assert 200 == response.get("code")
 
 
-def test_redis_flushdb(setup_client):
-    response = setup_client.redis.flushdb(REDIS_COLLECTION)
+def test_redis_flushdb(get_client_instance):
+    response = get_client_instance.redis.flushdb(REDIS_COLLECTION)
     # Response from platform
     assert {"code": 200, "result": "OK"} == response
 
 
-def test_redis_flushdb_2(setup_client):
-    response = setup_client.redis.flushdb(REDIS_COLLECTION, async_flush=True)
+def test_redis_flushdb_2(get_client_instance):
+    response = get_client_instance.redis.flushdb(REDIS_COLLECTION, async_flush=True)
     # Response from platform
     assert {"code": 200, "result": "OK"} == response
 
 
-def test_redis_time(setup_client):
-    response = setup_client.redis.time(REDIS_COLLECTION)
+def test_redis_time(get_client_instance):
+    response = get_client_instance.redis.time(REDIS_COLLECTION)
     # Response from platform
     assert 200 == response.get("code")
 
 
-def test_delete_redis_collection(setup_client):
-    response = setup_client.delete_collection(REDIS_COLLECTION)
+def test_delete_redis_collection(get_client_instance):
+    response = get_client_instance.delete_collection(REDIS_COLLECTION)
     # Response from platform
     assert True == response

--- a/tests/e2e/test_redis.py
+++ b/tests/e2e/test_redis.py
@@ -180,8 +180,7 @@ def test_redis_bitcount_2(get_client_instance):
 
 # This test fails
 # We support Redis commands till 6.2, bit/byte operation was added in 7.0
-# def test_redis_bitcount_3():
-#     get_client_instance = get_client_instance()
+# def test_redis_bitcount_3(get_client_instance):
 #
 #     response = get_client_instance.redis_bitcount("myKeyString", REDIS_COLLECTION, 1, 1, "BYTE")
 #     
@@ -1055,8 +1054,7 @@ def test_redis_persist(get_client_instance):
     assert {"code": 200, "result": 1} == response
 
 
-def test_redis_pexpire():
-    get_client_instance = get_client_instance()
+def test_redis_pexpire(get_client_instance):
     get_client_instance.redis.set("pexpire", "test", REDIS_COLLECTION)
     response = get_client_instance.redis.pexpire("pexpire", 8000, REDIS_COLLECTION)
     # Response from platform

--- a/tests/e2e/test_sql.py
+++ b/tests/e2e/test_sql.py
@@ -1,4 +1,4 @@
-from conftest import get_client_instance, test_data_document
+from conftest import test_data_document
 
 """
 Tests need to be run in sequence since we first create collection, after that we fill 
@@ -8,12 +8,11 @@ collection with test data data, run tests and check for the results.
 SQL_COLLECTION = "testsqlcollection"
 
 
-def test_create_redis_collection():
-    client = get_client_instance()
-    create_collection_response = client.create_collection(
+def test_create_redis_collection(get_client_instance):
+    create_collection_response = get_client_instance.create_collection(
         SQL_COLLECTION
     )
-    insert_document_response = client.insert_document(
+    insert_document_response = get_client_instance.insert_document(
         SQL_COLLECTION,
         silent=True,
         document=test_data_document()
@@ -23,9 +22,8 @@ def test_create_redis_collection():
     assert SQL_COLLECTION == create_collection_response.name
 
 
-def test_sql_endpoint():
-    client = get_client_instance()
-    cursor = client.execute_query(
+def test_sql_endpoint(get_client_instance):
+    cursor = get_client_instance.execute_query(
         'SELECT * FROM {}'.format(SQL_COLLECTION),
         sql=True
     )
@@ -40,8 +38,7 @@ def test_sql_endpoint():
     assert test_data_document() == docs
 
 
-def test_delete_sql_collection():
-    client = get_client_instance()
-    response = client.delete_collection(SQL_COLLECTION)
+def test_delete_sql_collection(get_client_instance):
+    response = get_client_instance.delete_collection(SQL_COLLECTION)
     # Response from platform
     assert True == response

--- a/tests/test_c8ql.py
+++ b/tests/test_c8ql.py
@@ -181,16 +181,13 @@ def test_c8ql_query_management(client, tst_fabric_name, bad_fabric_name, col, do
 
     bad_fabric = client._tenant.useFabric(bad_fabric_name)
     # Test list queries with bad fabric
-    with assert_raises(C8QLQueryListError) as err:
+    with assert_raises(C8QLQueryListError):
         bad_fabric.c8ql.queries()
-    assert err.value.error_code == 11
 
     # Test list slow queries with bad fabric
-    with assert_raises(C8QLQueryListError) as err:
+    with assert_raises(C8QLQueryListError):
         bad_fabric.c8ql.slow_queries()
-    assert err.value.error_code == 11
 
     # Test clear slow queries with bad fabric
-    with assert_raises(C8QLQueryClearError) as err:
+    with assert_raises(C8QLQueryClearError):
         bad_fabric.c8ql.clear_slow_queries()
-    assert err.value.error_code == 11

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -112,9 +112,8 @@ def test_collection_management(sys_fabric, client, bad_fabric):
     assert col_name in extract('name', sys_fabric.collections())
     bad = client._tenant.useFabric(bad_fabric)
     # Test list collections with bad fabric
-    with assert_raises(CollectionListError) as err:
+    with assert_raises(CollectionListError):
         bad.collections()
-    assert err.value.error_code == 11
 
     # Test get collection object
     sys_fabric = client._tenant.useFabric('_system')

--- a/tests/test_fabric.py
+++ b/tests/test_fabric.py
@@ -22,9 +22,9 @@ def test_fabric_misc_methods(fabric, client):
     assert properties['name'] == fabric.name
     assert properties['system'] is False
     # Test get properties with bad fabric
-    with assert_raises(FabricPropertiesError) as err:
+    with assert_raises(FabricPropertiesError):
         client._tenant.useFabric(generate_fabric_name()).properties()
-    assert err.value.error_code == 11
+
     # Test fabric details method
     details = fabric.fabrics_detail()
     assert 'associated_regions' in details[0]['options']

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -171,9 +171,8 @@ def test_vertex_collection_management(tst_fabric, graph, bad_graph, client):
     assert tvcol_name in extract('name', tst_fabric.collections())
 
     # Test list vertex collection via bad fabric
-    with assert_raises(VertexCollectionListError) as err:
+    with assert_raises(VertexCollectionListError):
         client._tenant.useFabric(generate_graph_name()).graph(bad_graph.name).vertex_collections()
-    assert err.value.error_code == 11
 
     # Test delete missing vertex collection
     with assert_raises(VertexCollectionDeleteError) as err:

--- a/tests/test_keyvalue.py
+++ b/tests/test_keyvalue.py
@@ -75,17 +75,14 @@ def test_keyvalue_exceptions(client, tst_fabric_name, bad_fabric_name):
     # Tests with bad fabric (non existing)
     client._tenant.useFabric(bad_fabric_name)
 
-    with assert_raises(CreateCollectionError) as err:
+    with assert_raises(CreateCollectionError):
         client.create_collection_kv(bad_col_name)
-    assert err.value.http_code == 401
     
-    with assert_raises(ListCollections) as err:
+    with assert_raises(ListCollections):
         client.has_collection_kv(bad_col_name)
-    assert err.value.http_code == 401
 
-    with assert_raises(ListCollections) as err:
+    with assert_raises(ListCollections):
         client.get_collections_kv()
-    assert err.value.http_code == 401
 
     # Tests with good fabric but bad collection
     client._tenant.useFabric(tst_fabric_name)

--- a/tests/test_query_workers.py
+++ b/tests/test_query_workers.py
@@ -143,14 +143,12 @@ def test_restql_exceptions(client, tst_fabric_name, col, bad_fabric_name):
 
     # Get restqls from invalid fabric
     client._tenant.useFabric(bad_fabric_name)
-    with assert_raises(RestqlListError) as err:
+    with assert_raises(RestqlListError):
         client.get_restqls()
-    assert err.value.http_code == 401
 
     # Delete restql from invalid fabric
-    with assert_raises(RestqlDeleteError) as err:
+    with assert_raises(RestqlDeleteError):
         client.delete_restql("insertRecord")
-    assert err.value.http_code == 401
 
     client._tenant.useFabric(tst_fabric_name)
 

--- a/tests/test_query_workers.py
+++ b/tests/test_query_workers.py
@@ -57,7 +57,7 @@ def test_restql_methods(client, tst_fabric_name, col):
     # Create and import queries
     client.create_restql(insert_data)
     client.import_restql(queries)
-    time.sleep(5)
+    time.sleep(2)
 
     resp = str(client.get_restqls())
     assert "getRecords" in resp

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,30 +1,19 @@
 from __future__ import absolute_import, unicode_literals
-import time
 
 from c8.exceptions import (
     SearchCollectionSetError,
-    SearchCollectionInvalidArgument,
-    SearchCollectionForbiddenError,
     SearchError,
-    SearchInvalidArgumentError,
-    SearchForbiddenError,
-    SearchNotExistError,
     ViewCreateError,
-    ViewCreateViewNameMissingError,
-    ViewCreateViewNameUnknownError,
     ViewGetError,
-    ViewNotFoundError,
     ViewRenameError,
     ViewDeleteError,
     ViewGetPropertiesError,
     ViewUpdatePropertiesError,
     AnalyzerListError,
     AnalyzerGetDefinitionError,
-    AnalyzerNotFoundError
 )
 from tests.helpers import (
     assert_raises,
-    generate_col_name,
     extract
 )
 
@@ -111,24 +100,20 @@ def test_search_exceptions(client, tst_fabric_name, col, docs, bad_fabric_name, 
     client._tenant.useFabric(bad_fabric_name)
 
     # Test set search in bad fabric
-    with assert_raises(SearchCollectionSetError) as err:
+    with assert_raises(SearchCollectionSetError):
         client.set_search(col.name, "true", "text")
-    assert err.value.http_code == 401
 
     # Test list all views in bad fabric
-    with assert_raises(ViewGetError) as err:
+    with assert_raises(ViewGetError):
         client.list_all_views()
-    assert err.value.http_code == 401
 
     # Test list all analyzers in bad fabric
-    with assert_raises(AnalyzerListError) as err:
+    with assert_raises(AnalyzerListError):
         client.get_list_of_analyzer()
-    assert err.value.http_code == 401
 
     # Test get analyzer definition in bad fabric
-    with assert_raises(AnalyzerGetDefinitionError) as err:
+    with assert_raises(AnalyzerGetDefinitionError):
         client.get_analyzer_definition("identity")
-    assert err.value.http_code == 401
 
     client._tenant.useFabric(tst_fabric_name)
     # Test search in bad collection

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 import json
 import base64
-import threading
 
 from c8.exceptions import (
     StreamCreateError,
@@ -30,54 +29,45 @@ def test_stream_methods(tst_fabric):
 
     assert stream.set_message_expiry_stream(stream_2, 3600) is True
 
-    def create_subscriber():
-        subscriber = stream.subscribe(stream_name_1, local=False, subscription_name="topic_1", consumer_type=stream.CONSUMER_TYPES.EXCLUSIVE)
+    # Create subscriber
+    subscriber = stream.subscribe(stream_name_1, local=False, subscription_name="topic_1")
+    # Producer publishing message
+    producer = stream.create_producer(stream_name_1, local=False)
+    msg = "Hello from  user"
+    producer.send(msg)
 
-        for i in range(10):
-            m1 = json.loads(subscriber.recv())
-            msg1 = base64.b64decode(m1["payload"]).decode('utf-8')
-            msg = "Hello from  user--" +  "("+ str(i) +")"
-            assert msg1 == msg
-            subscriber.send(json.dumps({'messageId': m1['messageId']}))#Acknowledge the received msg.
-        subscriber.close()
+    # Subscriber reading message
+    m1 = json.loads(subscriber.recv())
+    msg1 = base64.b64decode(m1["payload"]).decode('utf-8')
+    msg = "Hello from  user"
+    assert msg1 == msg
+    subscriber.send(json.dumps({'messageId': m1['messageId']}))#Acknowledge the received msg.
 
-    subscriber_thread = threading.Thread(target=create_subscriber)
-    subscriber_thread.start()
-
-    stream = tst_fabric.stream()
-    producer = stream.create_producer(stream_name_1)
-
-    for i in range(10):
-        msg = "Hello from  user--" +  "("+ str(i) +")"
-        producer.send(msg)
     producer.close()
+    subscriber.close()
 
-    subscriber_thread.join()
+    stream.get_stream_backlog(stream_name_2, local=True)
+    assert stream.clear_streams_backlog() == 'OK'
+    assert stream.clear_stream_backlog("topic_1") == 'OK'
+    stream.get_stream_stats(stream_name_1)
 
     reader = stream.create_reader(stream_name_2, "latest", local=True)
     subscriber_2 = stream.subscribe(stream_name_1, subscription_name="topic_2")
 
-    assert stream.get_message_stream_ttl() == 86400
     stream.set_message_stream_ttl(1000)
     assert stream.get_message_stream_ttl() == 1000
+
+    resp = stream.get_stream_subscriptions(stream_name_1)
+    assert resp == ['topic_1', 'topic_2']
 
     assert stream.publish_message_stream(stream_1, "Hello World") is True
     m1 = json.loads(subscriber_2.recv())
     msg1 = base64.b64decode(m1["payload"]).decode('utf-8')
     assert msg1 == "Hello World"
     subscriber_2.send(json.dumps({'messageId': m1['messageId']}))#Acknowledge the received msg.
-
-    resp = stream.get_stream_subscriptions(stream_name_1)
-    assert resp == ['topic_1', 'topic_2']
-
-    stream.get_stream_backlog(stream_name_1)
-    assert stream.clear_streams_backlog() == 'OK'
-    assert stream.clear_stream_backlog("topic_1") == 'OK'
-    stream.get_stream_stats(stream_name_1)
-
     subscriber_2.close()
     reader.close()
-
+ 
     assert stream.unsubscribe(subscription="topic_2") == 'OK'
     assert stream.delete_stream_subscription(stream_1, "topic_1") == 'OK'
 

--- a/tests/test_streamapps.py
+++ b/tests/test_streamapps.py
@@ -113,7 +113,7 @@ def test_streamapp_methods(client):
 
     regions = []
     result = app.update(updated_definition, regions)
-    time.sleep(10)
+    time.sleep(5)
     app.change_state(True)
 
     insert_data_value = ("INSERT { \"weight\": @weight } IN SampleCargoAppInputTable")
@@ -125,14 +125,14 @@ def test_streamapp_methods(client):
     }
 
     client.create_restql(insert_data_query)
-    time.sleep(30)
+    time.sleep(5)
     
     for i in range(10):
         client.execute_restql(
         "insertTestWeight", {"bindVars": {"weight": i}}
         )
 
-    time.sleep(5)
+    time.sleep(2)
     # Run query on application
     q = "select * from SampleCargoAppDestTable limit 3"
     result = app.query(q)
@@ -184,7 +184,7 @@ def test_streamapp_http_source(client):
     client.create_stream_app(data=stream_app_definition)
     # Activate a stream application
     client.activate_stream_app('Sample-HTTP-Source', True)
-    time.sleep(10)
+    time.sleep(2)
     stream = client._fabric.stream()
     def create_reader():
         reader = stream.create_reader('SampleHTTPOutputStream', "earliest", local=True)
@@ -235,11 +235,9 @@ def test_streamapp_exceptions(client, bad_fabric_name):
     regions = []
     resp = app.update(updated_definition, regions)
     assert resp['error'] is True
-    assert resp['code'] == 500
 
-    with assert_raises(StreamAppChangeActiveStateError) as err:
+    with assert_raises(StreamAppChangeActiveStateError):
         app.change_state(True)
-    assert err.value.http_code == 500
 
     # Run query on application
     q = "select * from SampleCargoAppDestTable limit 3"
@@ -248,8 +246,7 @@ def test_streamapp_exceptions(client, bad_fabric_name):
     # Delete a stream application
     assert client.delete_stream_app('Sample-Cargo-App') is False
     # Get stream application samples
-    with assert_raises(StreamAppGetSampleError) as err:
+    with assert_raises(StreamAppGetSampleError):
         client.get_stream_app_samples()
-    assert err.value.http_code == 500
     assert client.publish_message_http_source('Sample-HTTP-Source', 'SampleHTTPSource', {'carId': 'c1', 'longitude': 18.4334, 'latitude': 30.2123}) is False
 

--- a/tests/test_streamapps.py
+++ b/tests/test_streamapps.py
@@ -220,9 +220,8 @@ def test_streamapp_exceptions(client, bad_fabric_name):
     # Get a stream application handle for advanced operations
     assert client.get_stream_app('Sample-Cargo-App') is False
     # Activate a stream application
-    with assert_raises(StreamAppChangeActiveStateError) as err:
+    with assert_raises(StreamAppChangeActiveStateError):
         client.activate_stream_app('Sample-Cargo-App', True)
-    assert err.value.http_code == 500
 
     # To operate on created apps, you need to create an instance of the app
     app = client._fabric.stream_app("Sample-Cargo-App")


### PR DESCRIPTION
## Description

1. Added Billing APIs
2. Moved client and mm_client as global in conftest.py and added fixtures   in conftest.py so that all tests can access these client instances and reuse them across e2e tests (right now the C8Client constructor is called every time in e2e tests which means an API is called unnecessarily every time)
3. Updated test_stream.py to reduce test execution time significantly
4. Changed user endpoint in connection.py to the current one /_api/user from /_fabric/fabric/_api/user
5. Fixing failing flaky tests (now we should have 100% green on running python -m pytest in tests folder)
6. Also reduced sleep time required for some tests

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Reviews

Please identify two developers to review this change

- [ ] @dlozina-macrometa 
- [ ] @edgargarciamacrometa 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added new functional tests that prove my fix is effective or that my feature works
- [x] Existing and new functional tests pass with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
