### PR TITLE
Pydr 128 get collection information export data query endpoints

### DIFF
--- a/c8/c8ql.py
+++ b/c8/c8ql.py
@@ -321,3 +321,28 @@ class C8QL(APIWrapper):
             return True
 
         return self._execute(request, response_handler)
+
+    def export_data_query(self, query, bind_vars):
+        """Run the query and return list of result documents. Query cannot contain
+         the following keywords: INSERT, UPDATE, REPLACE, REMOVE and UPSERT.
+
+        :param query: C8QL query to execute
+        :type query: str
+        :param bind_vars: C8QL supports the usage of bind parameters, thus allowing to
+         separate the query text from literal values used in the query.
+        :type bind_vars: dict
+        :returns: Documents in the collection according to the query logic.
+        :rtype: dict
+        :raise c8.exceptions.C8QLQueryExecuteError: If export fails.
+        """
+        data = {"query": query}
+        if bind_vars is not None:
+            data["bindVars"] = bind_vars
+        request = Request(method="POST", endpoint="/export", data=data)
+
+        def response_handler(resp):
+            if not resp.is_success:
+                raise C8QLQueryExecuteError(resp, request)
+            return resp.body
+
+        return self._execute(request, response_handler)

--- a/c8/client.py
+++ b/c8/client.py
@@ -197,6 +197,27 @@ class C8Client(object):
     def collection(self, collection_name):
         return self._fabric.collection(collection_name)
 
+    def get_collection_information(self, collection_name):
+        """Fetch the information about collection.
+
+        :param collection_name: Collection name.
+        :type collection_name: str | unicode
+        :returns: information about collection as  searchEnabled, globallyUniqueId,
+        isSystem, waitForSync, hasStream, isLocal, isSpot,collectionModel, type, id.
+        :rtype: dict
+        """
+        return self._fabric.get_collection_information(collection_name)
+
+    def collection_figures(self, collection_name):
+        """Returns an object containing statistics about a collection.
+
+        :param collection_name: Collection name.
+        :type collection_name: str | unicode
+        :returns: statistics related with cache, index, document size, key options
+        :rtype: dict
+        """
+        return self._fabric.collection_figures(collection_name)
+
     # client.create_collection
     def create_collection(
         self,

--- a/c8/client.py
+++ b/c8/client.py
@@ -206,7 +206,8 @@ class C8Client(object):
         isSystem, waitForSync, hasStream, isLocal, isSpot,collectionModel, type, id.
         :rtype: dict
         """
-        return self._fabric.get_collection_information(collection_name)
+        collection = self.collection(collection_name)
+        return collection.get_collection_information(collection_name)
 
     def collection_figures(self, collection_name):
         """Returns an object containing statistics about a collection.
@@ -216,7 +217,8 @@ class C8Client(object):
         :returns: statistics related with cache, index, document size, key options
         :rtype: dict
         """
-        return self._fabric.collection_figures(collection_name)
+        collection = self.collection(collection_name)
+        return collection.collection_figures(collection_name)
 
     # client.create_collection
     def create_collection(

--- a/c8/client.py
+++ b/c8/client.py
@@ -1173,6 +1173,21 @@ class C8Client(object):
         """
         return self._fabric.c8ql.kill(query_id)
 
+    def export_data_query(self, query, bind_vars=None):
+        """Run the query and return list of result documents. Query cannot contain
+         the following keywords: INSERT, UPDATE, REPLACE, REMOVE and UPSERT.
+
+        :param query: C8QL query to execute
+        :type query: str
+        :param bind_vars: C8QL supports the usage of bind parameters, thus allowing to
+         separate the query text from literal values used in the query.
+        :type bind_vars: dict
+        :returns: Documents in the collection according to the query logic.
+        :rtype: dict
+        :raise c8.exceptions.C8QLQueryExecuteError: If export fails.
+        """
+        return self._fabric.c8ql.export_data_query(query=query, bind_vars=bind_vars)
+
     # client.create_restql
 
     def create_restql(self, data):

--- a/c8/collection.py
+++ b/c8/collection.py
@@ -7,6 +7,7 @@ from numbers import Number
 from c8.api import APIWrapper
 from c8.cursor import Cursor
 from c8.exceptions import (
+    CollectionPropertiesError,
     CollectionTruncateError,
     DocumentCountError,
     DocumentDeleteError,
@@ -262,6 +263,44 @@ class Collection(APIWrapper):
         :rtype: str | unicode
         """
         return self._name
+
+    def get_collection_information(self):
+        """Fetch the information about collection.
+
+        :returns: information about collection as  searchEnabled, globallyUniqueId,
+        isSystem, waitForSync, hasStream, isLocal, isSpot,collectionModel, type, id.
+        :rtype: dict
+        """
+        request = Request(
+            method="get",
+            endpoint="/collection/{}".format(self.name),
+        )
+
+        def response_handler(resp):
+            if resp.is_success:
+                return resp.body
+            raise CollectionPropertiesError(resp, request)
+
+        return self._execute(request, response_handler)
+
+    def collection_figures(self):
+        """Returns an object containing statistics about a collection.
+
+        :returns: statistics related with cache, index, document size, key options
+        :rtype: dict
+        """
+
+        request = Request(
+            method="get",
+            endpoint="/collection/{}/figures".format(self.name),
+        )
+
+        def response_handler(resp):
+            if resp.is_success:
+                return resp.body
+            raise CollectionPropertiesError(resp, request)
+
+        return self._execute(request, response_handler)
 
     def truncate(self):
         """Delete all documents in the collection.

--- a/c8/exceptions.py
+++ b/c8/exceptions.py
@@ -311,6 +311,10 @@ class BatchExecuteError(C8ServerError):
 #########################
 
 
+class CollectionFindError(C8ClientError):
+    """Failed to retrieve collection."""
+
+
 class CollectionListError(C8ServerError):
     """Failed to retrieve collections."""
 

--- a/c8/fabric.py
+++ b/c8/fabric.py
@@ -729,31 +729,6 @@ class Fabric(APIWrapper):
 
         return self._execute(request, response_handler)
 
-    def collection_figures(self, collection_name):
-        """Returns an object containing statistics about a collection.
-
-        :param collection_name: Collection name.
-        :type collection_name: str | unicode
-        :returns: statistics related with cache, index, document size, key options
-        :rtype: dict
-        """
-
-        collection = self.collection(name=collection_name)
-        return collection.collection_figures()
-
-    def get_collection_information(self, collection_name):
-        """Fetch the information about collection.
-
-        :param collection_name: Collection name.
-        :type collection_name: str | unicode
-        :returns: information about collection as  searchEnabled, globallyUniqueId,
-        isSystem, waitForSync, hasStream, isLocal, isSpot,collectionModel, type, id.
-        :rtype: dict
-        """
-
-        collection = self.collection(name=collection_name)
-        return collection.get_collection_information()
-
     def update_collection_properties(
         self, collection_name, has_stream=None, wait_for_sync=None
     ):

--- a/c8/fabric.py
+++ b/c8/fabric.py
@@ -14,6 +14,7 @@ from c8.collection import StandardCollection
 from c8.exceptions import (
     CollectionCreateError,
     CollectionDeleteError,
+    CollectionFindError,
     CollectionListError,
     CollectionPropertiesError,
     EventCreateError,
@@ -572,7 +573,7 @@ class Fabric(APIWrapper):
         if self.has_collection(name):
             return StandardCollection(self._conn, self._executor, name)
         else:
-            raise Exception("Collection not found")
+            raise CollectionFindError("Collection not found")
 
     def has_collection(self, name):
         """Check if collection exists in the fabric.
@@ -733,19 +734,25 @@ class Fabric(APIWrapper):
 
         :param collection_name: Collection name.
         :type collection_name: str | unicode
+        :returns: statistics related with cache, index, document size, key options
+        :rtype: dict
         """
 
-        request = Request(
-            method="get",
-            endpoint="/collection/{}/figures".format(collection_name),
-        )
+        collection = self.collection(name=collection_name)
+        return collection.collection_figures()
 
-        def response_handler(resp):
-            if resp.is_success:
-                return resp.body
-            raise CollectionPropertiesError(resp, request)
+    def get_collection_information(self, collection_name):
+        """Fetch the information about collection.
 
-        return self._execute(request, response_handler)
+        :param collection_name: Collection name.
+        :type collection_name: str | unicode
+        :returns: information about collection as  searchEnabled, globallyUniqueId,
+        isSystem, waitForSync, hasStream, isLocal, isSpot,collectionModel, type, id.
+        :rtype: dict
+        """
+
+        collection = self.collection(name=collection_name)
+        return collection.get_collection_information()
 
     def update_collection_properties(
         self, collection_name, has_stream=None, wait_for_sync=None

--- a/tests/e2e/test_collection.py
+++ b/tests/e2e/test_collection.py
@@ -99,7 +99,7 @@ def test_collection_figures(client, tst_fabric_name):
     collection_name = generate_col_name()
     fab = client._tenant.useFabric(tst_fabric_name)
     col = client.create_collection(collection_name, key_generator="autoincrement")
-    get_col_properties = fab.collection_figures(collection_name=col.name)
+    get_col_properties = fab.collection(col.name).collection_figures()
     if col.context != "transaction":
         assert "id" in get_col_properties
     assert get_col_properties["name"] == col.name

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -4,10 +4,33 @@ from c8.collection import StandardCollection
 from c8.exceptions import (
     CollectionCreateError,
     CollectionDeleteError,
+    CollectionFindError,
     CollectionListError,
     CollectionPropertiesError,
 )
 from tests.helpers import assert_raises, extract, generate_col_name
+
+
+def test_get_collection_information(client, col, tst_fabric_name):
+    tst_fabric = client._tenant.useFabric(tst_fabric_name)
+    collection = tst_fabric.collection(col.name)
+    # Test get information about collection
+    get_col_info = collection.get_collection_information()
+    assert get_col_info["error"] is False
+    assert get_col_info["name"] == collection.name
+    with assert_raises(CollectionFindError):
+        tst_fabric.get_collection_information(collection_name=generate_col_name())
+
+
+def test_collection_figures(client, col, tst_fabric_name):
+    # Test get properties
+    tst_fabric = client._tenant.useFabric(tst_fabric_name)
+    collection = tst_fabric.collection(col.name)
+    get_col_properties = collection.collection_figures()
+    assert get_col_properties["name"] == collection.name
+    assert get_col_properties["isSystem"] is False
+    with assert_raises(CollectionFindError):
+        tst_fabric.collection_figures(collection_name=generate_col_name())
 
 
 def test_collection_attributes(client, col, tst_fabric):
@@ -24,9 +47,8 @@ def test_collection_misc_methods(col, tst_fabric):
     assert get_col_properties["name"] == col.name
     assert get_col_properties["isSystem"] is False
     # Test get properties with bad collection
-    with assert_raises(CollectionPropertiesError) or assert_raises(Exception) as err:
+    with assert_raises(CollectionFindError):
         tst_fabric.collection_figures(collection_name=generate_col_name())
-    assert err.value.error_code == 1203
 
     # # Test configure properties
     prev_sync = get_col_properties["waitForSync"]


### PR DESCRIPTION
## Description

Added get_collection_information and collection_figures and export_data_query in client.py, also added their respective test_cases under test_collection for get_collection_information and test_c8ql for export_data_query, I took into consideration the comments from the old PR and the changes are made here.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Reviews

Please identify two developers to review this change

- [x] @koshy-thomas 
- [x] @dlozina-macrometa 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added new functional tests that prove my fix is effective or that my feature works
- [x] Existing and new functional tests pass with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
