### PR TITLE
Enhancing url_tester for all .md files in our repo and fixing data population for batchSize in execute_restql

### DIFF
--- a/c8/client.py
+++ b/c8/client.py
@@ -307,6 +307,25 @@ class C8Client(object):
         )
         return resp
 
+    # client.update_collection_properties
+    def update_collection_properties(
+        self, collection_name, has_stream=None, wait_for_sync=None
+    ):
+        """Changes the properties of a collection.
+           Note: except for waitForSync and hasStream, collection properties cannot be changed once a collection is created.
+        :param collection_name: Collection name.
+        :type collection_name: str | unicode
+        :param has_stream: True if creating a live collection stream.
+        :type has_stream: bool
+        :param wait_for_sync: True if all data must be synced to storage before operation returns.
+        :type wait_for_sync: bool
+        """
+        return self._fabric.update_collection_properties(
+            collection_name=collection_name,
+            has_stream=has_stream,
+            wait_for_sync=wait_for_sync
+        )
+
     # client.list_collection_indexes
     def list_collection_indexes(self, collection_name):
         """Delete the collection.

--- a/c8/fabric.py
+++ b/c8/fabric.py
@@ -1198,14 +1198,12 @@ class Fabric(APIWrapper):
         :raise c8.exceptions.RestqlExecuteError: if restql execution failed
         """
 
-        if data and "bindVars" in data:
-            request = Request(
-                method="post", data=data, endpoint="/restql/execute/%s" % name
-            )
-        else:
-            request = Request(
-                method="post", data={}, endpoint="/restql/execute/%s" % name
-            )
+        if data is None or not("bindVars" in data or "batchSize" in data):
+            data = {}
+
+        request = Request(
+            method="post", data=data, endpoint="/restql/execute/{}".format(name)
+        )
 
         def response_handler(resp):
             if not resp.is_success:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -6,8 +6,8 @@ from c8.collection import StandardCollection
 from c8.exceptions import (
     CollectionCreateError,
     CollectionDeleteError,
-    CollectionImportFromFileError,
     CollectionFindError,
+    CollectionImportFromFileError,
     CollectionListError,
     CollectionPropertiesError,
 )

--- a/tests/test_query_workers.py
+++ b/tests/test_query_workers.py
@@ -102,7 +102,7 @@ def test_restql_methods(client, tst_fabric_name, col):
     client.update_restql("insertRecord", updated_insert_data)
     time.sleep(2)
     client.execute_restql("insertRecord")
-    resp = client.execute_restql("getRecords", {"bindVars": {}, "batchSize": 2})
+    resp = client.execute_restql("getRecords", {"batchSize": 2})
 
     # Read next batch from cursor
     id = resp["id"]

--- a/tests/url_tester.py
+++ b/tests/url_tester.py
@@ -6,7 +6,7 @@ from urllib.request import urlopen, Request
 
 
 def get_md_files():
-    """ Return list of markdown files in root directory """
+    """ Return list of markdown files in root directory and subdirectories """
     files = []
     dir_path = r"../**/*.md"
     for file in glob.glob(dir_path, recursive=True):


### PR DESCRIPTION
## Description

Enhancing url_tester to automatically find urls from all .md files in our repo, detect if they are broken and identify the broken ones
As we add more and more links and especially website doc links (which tend to be restructured quickly) leading to broken links on our docs, this will help us identify all the broken links.

Added update_collection_properties method to client.py

Also, fixed data in execute restql method to populate data in execute restql API even if bindVars is not present in data but batchSize is present

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## Reviews

Please identify two developers to review this change

- [x] @dlozina-macrometa 
- [x] @edgargarciamacrometa 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added new functional tests that prove my fix is effective or that my feature works
- [x] Existing and new functional tests pass with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
