### PR TITLE
Removing some unwanted requirement packages

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -4,9 +4,5 @@ websocket-client==0.57.0
 certifi==2018.4.16
 chardet==3.0.4
 idna==2.7
-mccabe==0.6.1
-mock==2.0.0
-more-itertools==4.2.0
-pbr==4.1.0
 py==1.10.0
 six==1.11.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,4 +4,3 @@ pre-commit==2.20.0
 python-dotenv==0.21.0
 pluggy==1.0.0
 attrs==22.1.0
-atomicwrites==1.1.5


### PR DESCRIPTION
## Description

Removing some unwanted requirement packages. Unfortunately pytest has an internal dependency on six it seems so couldn't remove that. Similarly urllib3 is needed by requests package itself since requests package is actually built on top of urllib3.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

By running all pyC8 tests


## Reviews

Please identify two developers to review this change

- [ ] @dlozina-macrometa 
- [ ] @edgargarciamacrometa 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added new functional tests that prove my fix is effective or that my feature works
- [x] Existing and new functional tests pass with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
