### PR TITLE
Adding get_all_documents and get_all_batches

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -122,21 +122,28 @@ docs = [doc for doc in cursor]
 The Macrometa GDN has a default limit on how many documents can be returned per query. Usually, the default limit is 1,000 documents per query (This default limit is subject to changes).
 The following method should be used to retrieve data from a collection in batches despite this default limit of 1,000 documents per query.
 
+:::note
+Please make sure there is more than enough memory available on your system (RAM + Swap(if swap is enabled)) to be able fetch total size of the documents to be returned. This will help avoid any Out-Of-Memory problems.
+
 [See the full example here](./examples/get_data_in_batches.py)
+
+You need to specify the collection name in the `collection_name` parameter
 ```python
-collection_name = "result"
-document_count = fabric.collection(collection_name).count()
-iterations = int(math.ceil(document_count / 1000))
-data = []
+client.get_all_documents(collection_name="employees")
+```
 
-for i in range(iterations):
-    a = i * 1000
-    query = "FOR doc IN {} LIMIT {}, {} RETURN doc".format(collection_name, a, 1000)
-    cursor = fabric.c8ql.execute(query, count=True, batch_size=1000)
-    data.append(cursor.batch())
+## Returning all data records returned by any query via batches
+The Macrometa GDN has a default limit on how many documents can be returned per query. Usually, the default limit is 1,000 documents per query (This default limit is subject to changes). 
+The following method should be used to retrieve all the data from any query via batches despite this default limit of 1,000 documents per query.
 
-# Clean the data
-flat_data = [item for sublist in data for item in sublist]
+:::note
+Please make sure there is more than enough memory available on your system (RAM + Swap(if swap is enabled)) to be able fetch total size of the documents to be returned. This will help avoid any Out-Of-Memory problems.
+
+[See the full example here](./examples/get_data_in_batches.py)
+
+You need to specify your query in the `query` parameter
+```python
+client.get_all_batches(query="FOR doc IN employees FILTER doc.email LIKE '%macrometa.io' RETURN doc")
 ```
 
 # Query Workers

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -124,6 +124,7 @@ The following method should be used to retrieve data from a collection in batche
 
 :::note
 Please make sure there is more than enough memory available on your system (RAM + Swap(if swap is enabled)) to be able fetch total size of the documents to be returned. This will help avoid any Out-Of-Memory problems.
+:::
 
 [See the full example here](./examples/get_data_in_batches.py)
 
@@ -138,6 +139,7 @@ The following method should be used to retrieve all the data from any query via 
 
 :::note
 Please make sure there is more than enough memory available on your system (RAM + Swap(if swap is enabled)) to be able fetch total size of the documents to be returned. This will help avoid any Out-Of-Memory problems.
+:::
 
 [See the full example here](./examples/get_data_in_batches.py)
 

--- a/c8/c8ql.py
+++ b/c8/c8ql.py
@@ -350,12 +350,14 @@ class C8QL(APIWrapper):
         return self._execute(request, response_handler)
 
 
-    def get_all_batches(self, query, batch_size=1000, sql=False):
+    def get_all_batches(self, query, bind_vars=None, batch_size=1000, sql=False):
         """Returns all batches for a query. It should only be used for Read operations. Query cannot contain
          the following keywords: INSERT, UPDATE, REPLACE, REMOVE and UPSERT.
 
         :param query: Query to Execute
         :type query: str
+        :param bind_vars: Bind variables for the query.
+        :type bind_vars: dict
         :param batch_size: Batch size is a configurable number. Results are retieved by continuously 
             calling the next batch of cursor of size batch_size
         :type batch_size: int
@@ -369,7 +371,7 @@ class C8QL(APIWrapper):
         if (any(ele in query.upper() for ele in write_ops)):
             raise C8QLGetAllBatchesError("Write operations provided in the query. Only read operations can be provided")
 
-        cursor = self.execute(query=query, batch_size=batch_size, stream=True, sql=sql)
+        cursor = self.execute(query=query, bind_vars=bind_vars, batch_size=batch_size, stream=True, sql=sql)
         while cursor.has_more():
             cursor.fetch()
 

--- a/c8/c8ql.py
+++ b/c8/c8ql.py
@@ -350,7 +350,7 @@ class C8QL(APIWrapper):
         return self._execute(request, response_handler)
 
 
-    def get_all_batches(self, query, bind_vars=None, batch_size=1000, sql=False):
+    def get_all_batches(self, query, bind_vars=None, batch_size=1000):
         """Returns all batches for a query. It should only be used for Read operations. Query cannot contain
          the following keywords: INSERT, UPDATE, REPLACE, REMOVE and UPSERT.
 
@@ -361,8 +361,6 @@ class C8QL(APIWrapper):
         :param batch_size: Batch size is a configurable number. Results are retieved by continuously 
             calling the next batch of cursor of size batch_size
         :type batch_size: int
-        :param sql: Specify *true* and write sql query.
-        :type sql: bool
         :returns: Documents, or None if not found.
         :rtype: dict | None
         :raise c8.exceptions.C8QLQueryExecuteError: If retrieval fails.
@@ -371,7 +369,7 @@ class C8QL(APIWrapper):
         if (any(ele in query.upper() for ele in write_ops)):
             raise C8QLGetAllBatchesError("Write operations provided in the query. Only read operations can be provided")
 
-        cursor = self.execute(query=query, bind_vars=bind_vars, batch_size=batch_size, stream=True, sql=sql)
+        cursor = self.execute(query=query, bind_vars=bind_vars, batch_size=batch_size, stream=True)
         while cursor.has_more():
             cursor.fetch()
 

--- a/c8/c8ql.py
+++ b/c8/c8ql.py
@@ -356,8 +356,8 @@ class C8QL(APIWrapper):
 
         :param query: Query to Execute
         :type query: str
-        :param batch_size: Batch size is a configurable number, After each loop the offset will
-        increment by the batch size and return the next set of values.
+        :param batch_size: Batch size is a configurable number. Results are retieved by continuously 
+            calling the next batch of cursor of size batch_size
         :type batch_size: int
         :param sql: Specify *true* and write sql query.
         :type sql: bool

--- a/c8/c8ql.py
+++ b/c8/c8ql.py
@@ -354,7 +354,10 @@ class C8QL(APIWrapper):
         """Returns all batches for a query. It should only be used for Read operations. Query cannot contain
          the following keywords: INSERT, UPDATE, REPLACE, REMOVE and UPSERT.
 
-        :param query: Query to Execute
+         Note: Please make sure there is more than enough memory available on your system (RAM + Swap(if swap is enabled))
+         to be able fetch total size of the documents to be returned. This will help avoid any Out-Of-Memory problems.
+
+        :param query: Query to execute
         :type query: str
         :param bind_vars: Bind variables for the query.
         :type bind_vars: dict

--- a/c8/client.py
+++ b/c8/client.py
@@ -666,7 +666,11 @@ class C8Client(object):
     # client.get_all_documents
 
     def get_all_documents(self, collection_name, batch_size=1000):
-        """Return a list of documents.
+        """Return all the documents inside the given collection.
+
+         Note: Please make sure there is more than enough memory available on your system (RAM + Swap(if swap is enabled))
+         to be able fetch total size of the documents to be returned. This will help avoid any Out-Of-Memory problems.
+
         :param collection_name: Collection Name
         :type collection_name: str
         :param batch_size: Batch size is a configurable number. Results are retieved by continuously 
@@ -685,7 +689,10 @@ class C8Client(object):
 
     def get_all_batches(self, query, bind_vars=None, batch_size=1000):
         """Returns all batches for a query. It should only be used for Read operations. Query cannot contain
-        the following keywords: INSERT, UPDATE, REPLACE, REMOVE and UPSERT.
+         the following keywords: INSERT, UPDATE, REPLACE, REMOVE and UPSERT.
+
+         Note: Please make sure there is more than enough memory available on your system (RAM + Swap(if swap is enabled))
+         to be able fetch total size of the documents to be returned. This will help avoid any Out-Of-Memory problems.
 
         :param query: Query to Execute
         :type query: str

--- a/c8/client.py
+++ b/c8/client.py
@@ -663,6 +663,44 @@ class C8Client(object):
         resp = _collection.get(document=document, rev=rev, check_rev=check_rev)
         return resp
 
+    # client.get_all_documents
+
+    def get_all_documents(self, collection_name, batch_size=1000):
+        """Return a list of documents.
+        :param collection_name: Collection Name
+        :type collection_name: str
+        :param batch_size: Batch size is a configurable number. Results are retieved by continuously 
+            calling the next batch of cursor of size batch_size
+        :type batch_size: int
+        :returns: Documents, or None if not found.
+        :rtype: dict | None
+        :raise c8.exceptions.C8QLQueryExecuteError: If retrieval fails.
+        """
+        return self._fabric.c8ql.get_all_batches(
+            query="FOR doc IN {} RETURN doc".format(collection_name),
+            batch_size=batch_size,
+        )
+
+    # client.get_all_batches
+
+    def get_all_batches(self, query, batch_size=1000, sql=False):
+        """Returns all batches for a query. It should only be used for Read operations. Query cannot contain
+        the following keywords: INSERT, UPDATE, REPLACE, REMOVE and UPSERT.
+
+        :param query: Query to Execute
+        :type query: str
+        :param batch_size: Batch size is a configurable number. Results are retieved by continuously 
+            calling the next batch of cursor of size batch_size
+        :type batch_size: int
+        :param sql: Specify *true* and write sql query.
+        :type sql: bool
+        :returns: Documents, or None if not found.
+        :rtype: dict | None
+        :raise c8.exceptions.C8QLQueryExecuteError: If retrieval fails.
+        """
+
+        return self._fabric.c8ql.get_all_batches(query=query, batch_size=batch_size, sql=sql)
+
     # client.insert_document
 
     def insert_document(

--- a/c8/client.py
+++ b/c8/client.py
@@ -683,7 +683,7 @@ class C8Client(object):
 
     # client.get_all_batches
 
-    def get_all_batches(self, query, bind_vars=None, batch_size=1000, sql=False):
+    def get_all_batches(self, query, bind_vars=None, batch_size=1000):
         """Returns all batches for a query. It should only be used for Read operations. Query cannot contain
         the following keywords: INSERT, UPDATE, REPLACE, REMOVE and UPSERT.
 
@@ -694,8 +694,6 @@ class C8Client(object):
         :param batch_size: Batch size is a configurable number. Results are retieved by continuously 
             calling the next batch of cursor of size batch_size
         :type batch_size: int
-        :param sql: Specify *true* and write sql query.
-        :type sql: bool
         :returns: Documents, or None if not found.
         :rtype: dict | None
         :raise c8.exceptions.C8QLQueryExecuteError: If retrieval fails.
@@ -705,7 +703,6 @@ class C8Client(object):
             query=query,
             bind_vars=bind_vars,
             batch_size=batch_size,
-            sql=sql,
         )
 
     # client.insert_document

--- a/c8/client.py
+++ b/c8/client.py
@@ -701,7 +701,12 @@ class C8Client(object):
         :raise c8.exceptions.C8QLQueryExecuteError: If retrieval fails.
         """
 
-        return self._fabric.c8ql.get_all_batches(query=query, bind_vars=bind_vars, batch_size=batch_size, sql=sql)
+        return self._fabric.c8ql.get_all_batches(
+            query=query,
+            bind_vars=bind_vars,
+            batch_size=batch_size,
+            sql=sql,
+        )
 
     # client.insert_document
 

--- a/c8/client.py
+++ b/c8/client.py
@@ -683,12 +683,14 @@ class C8Client(object):
 
     # client.get_all_batches
 
-    def get_all_batches(self, query, batch_size=1000, sql=False):
+    def get_all_batches(self, query, bind_vars=None, batch_size=1000, sql=False):
         """Returns all batches for a query. It should only be used for Read operations. Query cannot contain
         the following keywords: INSERT, UPDATE, REPLACE, REMOVE and UPSERT.
 
         :param query: Query to Execute
         :type query: str
+        :param bind_vars: Bind variables for the query.
+        :type bind_vars: dict
         :param batch_size: Batch size is a configurable number. Results are retieved by continuously 
             calling the next batch of cursor of size batch_size
         :type batch_size: int
@@ -699,7 +701,7 @@ class C8Client(object):
         :raise c8.exceptions.C8QLQueryExecuteError: If retrieval fails.
         """
 
-        return self._fabric.c8ql.get_all_batches(query=query, batch_size=batch_size, sql=sql)
+        return self._fabric.c8ql.get_all_batches(query=query, bind_vars=bind_vars, batch_size=batch_size, sql=sql)
 
     # client.insert_document
 

--- a/c8/exceptions.py
+++ b/c8/exceptions.py
@@ -260,6 +260,10 @@ class C8QLFunctionDeleteError(C8ServerError):
     """Failed to delete C8QL user function."""
 
 
+class C8QLGetAllBatchesError(C8ClientError):
+    """Failed to retrieve all batches for the query"""
+
+
 ##############################
 # Async Execution Exceptions #
 ##############################

--- a/c8/utils.py
+++ b/c8/utils.py
@@ -3,10 +3,12 @@ from __future__ import absolute_import, unicode_literals
 import csv
 import json
 import logging
+from collections import deque
 from contextlib import contextmanager
 
 from six import string_types
 
+from c8.cursor import Cursor
 from c8.exceptions import DocumentParseError
 
 
@@ -117,3 +119,22 @@ def get_documents_from_file(data, index):
         index += 1
         documents.append(document)
     return documents, index
+
+
+def clean_doc(obj):
+    """Return the document(s) with all extra system keys stripped.
+    :param obj: document(s)
+    :type obj: list | dict | c8.cursor.Cursor
+    :return: Document(s) with the system keys stripped
+    :rtype: list | dict
+    """
+    if isinstance(obj, (Cursor, list, deque)):
+        docs = [clean_doc(d) for d in obj]
+        return docs
+
+    if isinstance(obj, dict):
+        return {
+            field: value
+            for field, value in obj.items()
+            if field in {"_key", "_from", "_to"} or not field.startswith("_")
+        }

--- a/examples/get_data_in_batches.py
+++ b/examples/get_data_in_batches.py
@@ -13,20 +13,13 @@ client.create_collection(collection_name)
 query = "FOR doc IN 1..2000 INSERT {{value: doc}} INTO {}".format(collection_name)
 cursor = client.execute_query(query=query)
 
-fabric = client._fabric
-# Get the document count of the collection to calculate iterations
-document_count = fabric.collection(collection_name).count()
-iterations = int(math.ceil(document_count / 1000))
-data = []
+# Return all documents in the collection
+docs_collection = client.get_all_documents(collection_name=collection_name)
 
-for i in range(iterations):
-    a = i * 1000
-    query = "FOR doc IN {} LIMIT {}, {} RETURN doc".format(collection_name, a, 1000)
-    cursor = fabric.c8ql.execute(query, count=True, batch_size=1000)
-    data.append(cursor.batch())
-
-# Clean the data
-flat_data = [item for sublist in data for item in sublist]
+# Return all documents returned by a query
+docs_query = client.get_all_batches(
+                query="FOR doc IN {} FILTER doc._key > 0 RETURN doc".format(collection_name)
+             )
 
 # Delete collection
 client.delete_collection(collection_name)

--- a/tests/test_c8ql.py
+++ b/tests/test_c8ql.py
@@ -276,7 +276,6 @@ def test_slow_queries(client, tst_fabric, bad_fabric_name):
 
 
 def test_get_all_batches(client, col, tst_fabric_name):
-    # Test for c8ql 
     document_count = 2003
     client._tenant.useFabric(tst_fabric_name)
     client.execute_query(
@@ -286,15 +285,6 @@ def test_get_all_batches(client, col, tst_fabric_name):
     )
     resp = client.get_all_batches(
         query="FOR doc IN {} FILTER doc._key > 0 RETURN doc".format(col.name)
-    )
-    assert document_count == len(resp)
-    for i in range(len(resp)):
-        assert resp[i]["value"] == i + 1
-
-    # Test for sql
-    resp = client.get_all_batches(
-        query="SELECT * FROM {}".format(col.name),
-        sql=True
     )
     assert document_count == len(resp)
     for i in range(len(resp)):

--- a/tests/test_c8ql.py
+++ b/tests/test_c8ql.py
@@ -4,6 +4,7 @@ import threading
 import time
 
 from c8.exceptions import (
+    C8QLGetAllBatchesError,
     C8QLQueryClearError,
     C8QLQueryExecuteError,
     C8QLQueryExplainError,
@@ -83,7 +84,6 @@ def test_export_data_query(client, docs, tst_fabric_name, col):
     assert resp["error"] is False
     assert resp["result"] == docs
 
-
 def test_c8ql_attributes(client, tst_fabric_name):
     tst_fabric = client._tenant.useFabric(tst_fabric_name)
     assert tst_fabric.context in ["default", "async", "batch", "transaction"]
@@ -91,8 +91,7 @@ def test_c8ql_attributes(client, tst_fabric_name):
     assert tst_fabric.fabric_name == tst_fabric.name
     assert repr(tst_fabric.c8ql) == "<C8QL in {}>".format(tst_fabric_name)
 
-
-def test_c8ql_query_management(client, tst_fabric_name, bad_fabric_name, col, docs):
+def test_explain_query(client, tst_fabric_name, col):
     tst_fabric = client._tenant.useFabric(tst_fabric_name)
     plan_fields = [
         "estimatedNrItems",
@@ -125,6 +124,8 @@ def test_c8ql_query_management(client, tst_fabric_name, bad_fabric_name, col, do
         assert all(field in plan for field in plan_fields)
     assert len(plans) < 10
 
+
+def test_validate_query(tst_fabric, col):
     # Test validate invalid query
     with assert_raises(C8QLQueryValidateError) as err:
         tst_fabric.c8ql.validate("INVALID QUERY")
@@ -137,6 +138,8 @@ def test_c8ql_query_management(client, tst_fabric_name, bad_fabric_name, col, do
     assert "collections" in result
     assert "parsed" in result
 
+
+def test_execute_query(tst_fabric, col, docs):
     # Test execute invalid C8QL query
     with assert_raises(C8QLQueryExecuteError) as err:
         tst_fabric.c8ql.execute("INVALID QUERY")
@@ -145,7 +148,7 @@ def test_c8ql_query_management(client, tst_fabric_name, bad_fabric_name, col, do
     # Test execute valid query
     tst_fabric.collection(col.name).import_bulk(docs)
     # Test for sql
-    cursor = tst_fabric.c8ql.execute(f"SELECT * FROM {col.name}", sql=True)
+    cursor = tst_fabric.c8ql.execute("SELECT * FROM {}".format(col.name), sql=True)
     doc_response = [doc for doc in cursor]
 
     entries = ("_id", "_rev")
@@ -200,6 +203,8 @@ def test_c8ql_query_management(client, tst_fabric_name, bad_fabric_name, col, do
         assert extract("_key", cursor) == extract("_key", docs)
         assert cursor.close(ignore_missing=True) is False
 
+
+def test_kill_query(tst_fabric):
     # Kick off some long lasting queries in the background
     def query():
         with assert_raises(C8QLQueryExecuteError) as err:
@@ -248,6 +253,8 @@ def test_c8ql_query_management(client, tst_fabric_name, bad_fabric_name, col, do
 
     run_queries()
 
+
+def test_slow_queries(client, tst_fabric, bad_fabric_name):
     # Test list slow queries
     assert tst_fabric.c8ql.slow_queries() == []
 
@@ -266,3 +273,85 @@ def test_c8ql_query_management(client, tst_fabric_name, bad_fabric_name, col, do
     # Test clear slow queries with bad fabric
     with assert_raises(C8QLQueryClearError):
         bad_fabric.c8ql.clear_slow_queries()
+
+
+def test_get_all_batches(client, col, tst_fabric_name):
+    # Test for c8ql 
+    document_count = 2003
+    client._tenant.useFabric(tst_fabric_name)
+    client.execute_query(
+        query="FOR doc IN 1..{} INSERT {{value:doc}} INTO {}".format(
+            document_count, col.name
+        )
+    )
+    resp = client.get_all_batches(
+        query="FOR doc IN {} FILTER doc._key > 0 RETURN doc".format(col.name)
+    )
+    assert document_count == len(resp)
+    for i in range(len(resp)):
+        assert resp[i]["value"] == i + 1
+
+    # Test for sql
+    resp = client.get_all_batches(
+        query="SELECT * FROM {}".format(col.name),
+        sql=True
+    )
+    assert document_count == len(resp)
+    for i in range(len(resp)):
+        assert resp[i]["value"] == i + 1
+    col.truncate()
+
+    document_count = 11
+    client.execute_query(
+        query="FOR doc IN 1..{} INSERT {{value:doc}} INTO {}".format(
+            document_count, col.name
+        )
+    )
+    resp = client.get_all_batches(
+        query="FOR doc IN {} FILTER doc._key > 0 RETURN doc".format(col.name)
+    )
+    assert document_count == len(resp)
+    for i in range(len(resp)):
+        assert resp[i]["value"] == i + 1
+    col.truncate()
+
+
+def test_invalid_get_all_batches(client, col, tst_fabric_name):
+    client._tenant.useFabric(tst_fabric_name)
+
+    # Testing invalid operation REMOVE
+    with assert_raises(C8QLGetAllBatchesError) as err:
+        client.get_all_batches(query='remove "1" in {}'.format(col.name))
+
+    # Testing invalid operation UPDATE
+    with assert_raises(C8QLGetAllBatchesError) as err:
+        client.get_all_batches(
+            query="UPDATE @id WITH {alive: false} IN @@collection",
+            bind_vars={"@collection": col.name, "id": 2},
+        )
+
+    # Testing invalid operation INSERT
+    with assert_raises(C8QLGetAllBatchesError) as err:
+        client.get_all_batches(
+            query="insert @value into @@collection",
+            bind_vars={"@collection": col.name, "value": {"value": 10}},
+        )
+
+    # Testing invalid operation REPLACE
+    with assert_raises(C8QLGetAllBatchesError) as err:
+        client.get_all_batches(
+            query="FOR u IN @@collection REPLACE @value IN @@collection",
+            bind_vars={"@collection": col.name, "value": {"value": 2, "text": "zoo "}},
+        )
+
+    # Testing invalid operation UPSERT
+    with assert_raises(C8QLGetAllBatchesError) as err:
+        client.get_all_batches(
+            query="UPSERT @value INSERT @toInsert UPDATE @toUpsert in @@collection",
+            bind_vars={
+                "@collection": col.name,
+                "value": {"text": "zoo "},
+                "toInsert": {"_key": 2, "updatedAt": "DATE_NOW()"},
+                "toUpsert": {"_key": 2, "updatedAt": "December"},
+            },
+        )

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -193,3 +193,30 @@ def test_insert_from_file(client, tst_fabric_name, col):
         == "<ExceptionInfo CollectionImportFromFileError('Invalid file') tblen=3>"
     )
     file.close()
+
+
+def test_all_documents(client, col, tst_fabric_name):
+    document_count = 2003
+    client._tenant.useFabric(tst_fabric_name)
+    client.execute_query(
+        query="FOR doc IN 1..{} INSERT {{value:doc}} INTO {}".format(
+            document_count, col.name
+        )
+    )
+    resp = client.get_all_documents(collection_name=col.name)
+
+    assert document_count == len(resp)
+    for i in range(len(resp)):
+        assert resp[i]["value"] == i + 1
+    col.truncate()
+
+    document_count = 11
+    client.execute_query(
+        query="FOR doc IN 1..{} INSERT {{value:doc}} INTO {}".format(
+            document_count, col.name
+        )
+    )
+    resp = client.get_all_documents(collection_name=col.name)
+    assert document_count == len(resp)
+    for i in range(len(resp)):
+        assert resp[i]["value"] == i + 1


### PR DESCRIPTION
## Description

Added function get_all_documents, get_all_batches. 
This is more convenient for users instead of trying to figure out how to get the rest of the docs and writing their own loops and logic.
This enhances user experience.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


* C8 Version:

## Reviews

Please identify two developers to review this change

- [ ] @amit-macrometa 
- [ ] @ivayloPetkov 
- [x] @dlozina-macrometa 
- [ ] @edgargarciamacrometa 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added new functional tests that prove my fix is effective or that my feature works
- [x] Existing and new functional tests pass with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
