### PR TITLE
C8Client should default to HTTPS

### DIFF
--- a/c8/client.py
+++ b/c8/client.py
@@ -26,9 +26,9 @@ class C8Client(object):
 
     def __init__(
         self,
-        protocol="http",
+        protocol="https",
         host="127.0.0.1",
-        port=80,
+        port=None,
         geofabric="_system",
         stream_port=constants.STREAM_PORT,
         email=None,

--- a/c8/client.py
+++ b/c8/client.py
@@ -37,6 +37,14 @@ class C8Client(object):
         token=None,
         apikey=None,
     ):
+        if port is None: # only force the port to default if user didn't supply an explicit port
+            if protocol == 'http':
+                port = 80
+            elif protocol == 'https':
+                port = 443
+            else:
+                raise NotImplementedError(f'Cannot determine default port for unsupported protocol: {protocol}')
+
         self._protocol = protocol.strip("/")
         self._host = host.strip("/")
         self._port = int(port)


### PR DESCRIPTION
## Description

The default should be HTTPS. Additionally, the default port varies depending on protocol, so we should calculate it thusly.

Closes #95 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

No, not at all. Needs to be tested before merge

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added new functional tests that prove my fix is effective or that my feature works
- [ ] Existing and new functional tests pass with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
