### PR TITLE
Add support for strong consistency property

### DIFF
--- a/c8/collection.py
+++ b/c8/collection.py
@@ -276,7 +276,7 @@ class Collection(APIWrapper):
         """Fetch the information about collection.
 
         :returns: information about collection as  searchEnabled, globallyUniqueId,
-        isSystem, waitForSync, hasStream, isLocal, isSpot,collectionModel, type, id.
+        isSystem, waitForSync, hasStream, isLocal, strongConsistency, collectionModel, type, id.
         :rtype: dict
         """
         request = Request(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ def pytest_configure(config):
     password = "Sdk@1234!"
     tst_fabric_name = "test_fabric_1"
     bad_fabric_name = "test_fabric_2"
+    sys_fabric.delete_fabric(name=tst_fabric_name, ignore_missing=True)
     sys_fabric.create_fabric(name=tst_fabric_name, users=["root"])
     bad_fabric = tenant.useFabric(bad_fabric_name)
     tst_fabric = tenant.useFabric(tst_fabric_name)


### PR DESCRIPTION
## Description

isSpot property is removed from the collection properties in latest GDN versions. Instead we should use `strongConsistency` property. keyword only arguments is used in `createCollection` function to provide a backward compatible sdk interface to the users.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
- Ran the test suite.
- Verify with a local python script which uses the pyc8 sdk

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added new functional tests that prove my fix is effective or that my feature works
- [ ] Existing and new functional tests pass with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
